### PR TITLE
Add images/event endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.stestr
 
 # Translations
 *.mo

--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -284,6 +284,11 @@ class Client(object):
                               data={'url': image_url})
         return r.json()
 
+    def get_image_events(self, image_url):
+        r = self._request_url('GET', self.base_url + '/images/events',
+                              data={'url': image_url})
+        return r.json()
+
     def get_networks(self, all=False):
         r = self._request_url('GET', self.base_url +
                               '/networks', data={'all': all})


### PR DESCRIPTION
This new endpoint does not follow the standard format but we don't have image UUID at the moment. So this seems the neatest way (least coding effort) to pass image URLs?

See https://github.com/shakenfist/shakenfist/issues/422