### PR TITLE
Add command to list cached images

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -284,6 +284,11 @@ class Client(object):
                               data={'url': image_url})
         return r.json()
 
+    def get_image_meta(self, node=None):
+        r = self._request_url('GET', self.base_url + '/images',
+                              data={'node': node})
+        return r.json()
+
     def get_image_events(self, image_url):
         r = self._request_url('GET', self.base_url + '/images/events',
                               data={'url': image_url})

--- a/shakenfist_client/main.py
+++ b/shakenfist_client/main.py
@@ -174,16 +174,16 @@ def lock_list(ctx):
     locks = CLIENT.get_existing_locks()
 
     if ctx.obj['OUTPUT'] == 'pretty':
-        x = PrettyTable()   
+        x = PrettyTable()
         x.field_names = ['lock', 'pid', 'node']
-        for l, meta in locks.items():
-            x.add_row([l, meta['pid'], meta['node']])
+        for ref, meta in locks.items():
+            x.add_row([ref, meta['pid'], meta['node']])
         print(x)
 
     elif ctx.obj['OUTPUT'] == 'simple':
         print('lock,pid,node')
-        for l, meta in locks.items():
-            print('%s,%s,%s' % (l, meta['pid'], meta['node']))
+        for ref, meta in locks.items():
+            print('%s,%s,%s' % (ref, meta['pid'], meta['node']))
 
     elif ctx.obj['OUTPUT'] == 'json':
         print(json.dumps(locks))
@@ -1166,6 +1166,38 @@ def image_cache(ctx, image_url=None):
     CLIENT.cache_image(image_url)
     if ctx.obj['OUTPUT'] == 'json':
         print('{}')
+
+
+@image.command(name='list',
+               help='List cached images.\n\n'
+                    'NODE: Only list images cached on NODE')
+@click.option('--node', type=click.STRING)
+@click.pass_context
+def image_list(ctx, node=None):
+    images = CLIENT.get_image_meta(node)
+
+    if ctx.obj['OUTPUT'] == 'pretty':
+        x = PrettyTable()
+        x.field_names = ['ref', 'node', 'url', 'size', 'modified', 'fetched',
+                         'file_version', 'checksum']
+        x.align['url'] = 'l'
+        x.sortby = 'url'
+        for meta in images:
+            x.add_row([meta['ref'], meta['node'], meta['url'], meta['size'],
+                       meta['modified'], meta['fetched'], meta['file_version'],
+                       meta['checksum']])
+        print(x)
+
+    elif ctx.obj['OUTPUT'] == 'simple':
+        print('ref,node,url,size,modified,fetched,file_version,checksum')
+        for meta in images:
+            print('%s,%s,%s,%s,%s,%s,%s,%s' % (
+                meta['ref'], meta['node'], meta['url'], meta['size'],
+                meta['modified'], meta['fetched'], meta['file_version'],
+                meta['checksum']))
+
+    elif ctx.obj['OUTPUT'] == 'json':
+        print(json.dumps(images))
 
 
 cli.add_command(image)

--- a/shakenfist_client/tests/test_client_apiclient.py
+++ b/shakenfist_client/tests/test_client_apiclient.py
@@ -158,6 +158,14 @@ class ApiClientTestCase(testtools.TestCase):
             'POST', 'http://localhost:13000/images',
             data={'url': 'imageurl'})
 
+    def test_get_image_meta(self):
+        client = apiclient.Client()
+        client.get_image_meta('sf-2')
+
+        self.mock_request.assert_called_with(
+            'GET', 'http://localhost:13000/images',
+            data={'node': 'sf-2'})
+
     def test_create_namespace(self):
         client = apiclient.Client()
         client.create_namespace('testspace')
@@ -279,6 +287,13 @@ class ApiClientTestCase(testtools.TestCase):
                 'name': 'gerkin',
                 'namespace': None
             })
+
+    def test_get_existing_locks(self):
+        client = apiclient.Client()
+        client.get_existing_locks()
+
+        self.mock_request.assert_called_with(
+            'GET', 'http://localhost:13000/admin/locks')
 
 
 class GetNodesMock():


### PR DESCRIPTION
```
root@sf-1:/srv/shakenfist/instances# sf-client image list 
+------------------------------------------------------------------+------+---------------------------------------------------------------------------------+-----------+-------------------------------+---------------------------------+--------------+----------------------------------+
|                               ref                                | node | url                                                                             |    size   |            modified           |             fetched             | file_version |             checksum             |
+------------------------------------------------------------------+------+---------------------------------------------------------------------------------+-----------+-------------------------------+---------------------------------+--------------+----------------------------------+
| aca4103de7b5636cd857b54cb0dd3770e7dd98500b6d4f1cefa18b052074e092 | sf-2 | http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img             |  16338944 | Fri, 06 Mar 2020 19:19:05 GMT | Wed, 21 Oct 2020 22:24:30 -0000 |      1       |               None               |
| 095fdd2b66627f1665a53623c77d00f82cd373602a0b445470ac0437885412aa | sf-2 | https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img | 359464960 | Fri, 16 Oct 2020 16:32:30 GMT | Wed, 21 Oct 2020 10:08:16 -0000 |      1       | ed44b9745b8d62bcbbc180b5f36c24bb |
| 095fdd2b66627f1665a53623c77d00f82cd373602a0b445470ac0437885412aa | sf-3 | https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img | 359464960 | Fri, 16 Oct 2020 16:32:30 GMT | Thu, 22 Oct 2020 01:20:19 -0000 |      1       | ed44b9745b8d62bcbbc180b5f36c24bb |
| 1b01f4bcb02f3a060610a4f73b34012d59197a12c2794b495dd583e43d0f65e8 | sf-2 | https://cloud-images.ubuntu.com/groovy/current/groovy-server-cloudimg-amd64.img | 558760448 | Thu, 22 Oct 2020 15:11:56 GMT | Fri, 23 Oct 2020 23:56:30 -0000 |      2       | ff26abf6a7b47feeeb34364bb915160d |
| 1b01f4bcb02f3a060610a4f73b34012d59197a12c2794b495dd583e43d0f65e8 | sf-3 | https://cloud-images.ubuntu.com/groovy/current/groovy-server-cloudimg-amd64.img | 558760448 | Thu, 22 Oct 2020 15:11:56 GMT | Fri, 23 Oct 2020 23:56:29 -0000 |      2       | ff26abf6a7b47feeeb34364bb915160d |
+------------------------------------------------------------------+------+---------------------------------------------------------------------------------+-----------+-------------------------------+---------------------------------+--------------+----------------------------------+
```