### PR TITLE
Retry when we recieve a 406 error.

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -14,7 +14,7 @@ on:
       - v*-devel
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,11 +22,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
 
       - name: Install dependencies
         run: |
@@ -37,14 +32,33 @@ jobs:
         run: |
           tox -eflake8
 
-      - name: Test with python 3.7
-        run: |
-          tox -epy37
+  build38:
+    runs-on: ubuntu-latest
 
-      - name: Test with python 3.7 again
-        run: |
-          tox -epy37
+    steps:
+      - name: Checkout code with two commits
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
-      - name: Test with python 3.7 again again
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
         run: |
-          tox -epy37
+          python -m pip install --upgrade pip
+          sudo apt-get install -y -q tox
+
+      - name: Test with python 3.8
+        run: |
+          tox -epy3
+
+      - name: Test with python 3.8 again
+        run: |
+          tox -epy3
+
+      - name: Test with python 3.8 again again
+        run: |
+          tox -epy3

--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -36,7 +36,7 @@ class ResourceNotFoundException(APIException):
     pass
 
 
-class DependanciesNotReadyException(APIException):
+class DependenciesNotReadyException(APIException):
     pass
 
 
@@ -57,7 +57,7 @@ STATUS_CODES_TO_ERRORS = {
     401: UnauthorizedException,
     403: ResourceCannotBeDeletedException,
     404: ResourceNotFoundException,
-    406: DependanciesNotReadyException,
+    406: DependenciesNotReadyException,
     409: ResourceInUseException,
     500: InternalServerError,
     507: InsufficientResourcesException,
@@ -161,7 +161,7 @@ class Client(object):
                 except UnauthorizedException:
                     self.cached_auth = self._authenticate()
                     return self._actual_request_url(method, url, data=data)
-            except DependanciesNotReadyException as e:
+            except DependenciesNotReadyException as e:
                 # The API server will return a 406 exception when we have
                 # specified an operation which depends on a resource and
                 # that resource is not in the created state. We retry

--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -36,6 +36,10 @@ class ResourceNotFoundException(APIException):
     pass
 
 
+class DependanciesNotReadyException(APIException):
+    pass
+
+
 class ResourceInUseException(APIException):
     pass
 
@@ -53,6 +57,7 @@ STATUS_CODES_TO_ERRORS = {
     401: UnauthorizedException,
     403: ResourceCannotBeDeletedException,
     404: ResourceNotFoundException,
+    406: DependanciesNotReadyException,
     409: ResourceInUseException,
     500: InternalServerError,
     507: InsufficientResourcesException,
@@ -148,11 +153,22 @@ class Client(object):
         if not self.cached_auth:
             self.cached_auth = self._authenticate()
 
-        try:
-            return self._actual_request_url(method, url, data=data)
-        except UnauthorizedException:
-            self.cached_auth = self._authenticate()
-            return self._actual_request_url(method, url, data=data)
+        start_time = time.time()
+        while True:
+            try:
+                try:
+                    return self._actual_request_url(method, url, data=data)
+                except UnauthorizedException:
+                    self.cached_auth = self._authenticate()
+                    return self._actual_request_url(method, url, data=data)
+            except DependanciesNotReadyException as e:
+                # The API server will return a 406 exception when we have
+                # specified an operation which depends on a resource and
+                # that resource is not in the created state. We retry
+                # for a while before we give up.
+                if time.time() - start_time > 30:
+                    raise e
+                time.sleep(1)
 
     def get_instances(self, all=False):
         r = self._request_url('GET', self.base_url +


### PR DESCRIPTION
The API server now uses HTTP status 406 to indicate that you've
specified an operation which depends on a resource which has not
yet made it to the created state (for example creating an
instance on a network which isn't built yet). This change adds
a retry for when the client sees that happen.