### PR TITLE
Allow callers to not read configuration.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -66,32 +66,34 @@ STATUS_CODES_TO_ERRORS = {
 
 class Client(object):
     def __init__(self, base_url='http://localhost:13000', verbose=False,
-                 namespace=None, key=None, sync_request_timeout=300):
+                 namespace=None, key=None, sync_request_timeout=300,
+                 suppress_configuration_lookup=False):
         self.sync_request_timeout = sync_request_timeout
 
-        # Where do we find authentication details? First off, we try command line
-        # flags; then environment variables (thanks for doing this for free click);
-        # and finally ~/.shakenfist (which is a JSON file).
-        if not namespace:
-            user_conf = os.path.expanduser('~/.shakenfist')
-            if os.path.exists(user_conf):
-                with open(user_conf) as f:
-                    d = json.loads(f.read())
-                    namespace = d['namespace']
-                    key = d['key']
-                    base_url = d['apiurl']
-
-        if not namespace:
-            try:
-                if os.path.exists('/etc/sf/shakenfist.json'):
-                    with open('/etc/sf/shakenfist.json') as f:
+        if not suppress_configuration_lookup:
+            # Where do we find authentication details? First off, we try command line
+            # flags; then environment variables (thanks for doing this for free click);
+            # and finally ~/.shakenfist (which is a JSON file).
+            if not namespace:
+                user_conf = os.path.expanduser('~/.shakenfist')
+                if os.path.exists(user_conf):
+                    with open(user_conf) as f:
                         d = json.loads(f.read())
                         namespace = d['namespace']
                         key = d['key']
                         base_url = d['apiurl']
-            except IOError as e:
-                if e.errno != errno.EACCES:
-                    raise
+
+            if not namespace:
+                try:
+                    if os.path.exists('/etc/sf/shakenfist.json'):
+                        with open('/etc/sf/shakenfist.json') as f:
+                            d = json.loads(f.read())
+                            namespace = d['namespace']
+                            key = d['key']
+                            base_url = d['apiurl']
+                except IOError as e:
+                    if e.errno != errno.EACCES:
+                        raise
 
         self.base_url = base_url
         self.namespace = namespace

--- a/shakenfist_client/tests/test_client_apiclient.py
+++ b/shakenfist_client/tests/test_client_apiclient.py
@@ -16,28 +16,28 @@ class ApiClientTestCase(testtools.TestCase):
         self.addCleanup(self.request_url.stop)
 
     def test_get_instances(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         list(client.get_instances())
 
         self.mock_request.assert_called_with(
             'GET', 'http://localhost:13000/instances', data={'all': False})
 
     def test_get_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_instance('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'GET', 'http://localhost:13000/instances/notreallyauuid')
 
     def test_get_instance_interfaces(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_instance_interfaces('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'GET', 'http://localhost:13000/instances/notreallyauuid/interfaces')
 
     def test_create_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.create_instance('foo', 1, 2048, ['netuuid1'], ['8@cirros'],
                                'sshkey', None, namespace=None, force_placement=None,
                                video={'model': 'cirrus', 'memory': 16384})
@@ -57,7 +57,7 @@ class ApiClientTestCase(testtools.TestCase):
             })
 
     def test_create_instance_user_data(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.create_instance('foo', 1, 2048, ['netuuid1'], ['8@cirros'],
                                'sshkey', 'userdatabeforebase64', namespace=None,
                                force_placement=None,
@@ -78,7 +78,7 @@ class ApiClientTestCase(testtools.TestCase):
             })
 
     def test_snapshot_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.snapshot_instance('notreallyauuid', all=True)
 
         self.mock_request.assert_called_with(
@@ -86,56 +86,56 @@ class ApiClientTestCase(testtools.TestCase):
             data={'all': True})
 
     def test_soft_reboot_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.reboot_instance('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'POST', 'http://localhost:13000/instances/notreallyauuid/rebootsoft')
 
     def test_hard_reboot_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.reboot_instance('notreallyauuid', hard=True)
 
         self.mock_request.assert_called_with(
             'POST', 'http://localhost:13000/instances/notreallyauuid/reboothard')
 
     def test_power_off_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.power_off_instance('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'POST', 'http://localhost:13000/instances/notreallyauuid/poweroff')
 
     def test_power_on_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.power_on_instance('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'POST', 'http://localhost:13000/instances/notreallyauuid/poweron')
 
     def test_pause_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.pause_instance('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'POST', 'http://localhost:13000/instances/notreallyauuid/pause')
 
     def test_unpause_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.unpause_instance('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'POST', 'http://localhost:13000/instances/notreallyauuid/unpause')
 
     def test_delete_instance(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_instance('notreallyauuid', async_request=True)
 
         self.mock_request.assert_called_with(
             'DELETE', 'http://localhost:13000/instances/notreallyauuid')
 
     def test_delete_all_instances(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_all_instances(None)
 
         self.mock_request.assert_called_with(
@@ -143,7 +143,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'confirm': True, 'namespace': None})
 
     def test_delete_all_instances_namespace(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_all_instances('bobspace')
 
         self.mock_request.assert_called_with(
@@ -151,7 +151,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'confirm': True, 'namespace': 'bobspace'})
 
     def test_cache_image(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.cache_image('imageurl')
 
         self.mock_request.assert_called_with(
@@ -159,7 +159,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'url': 'imageurl'})
 
     def test_get_image_meta(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_image_meta('sf-2')
 
         self.mock_request.assert_called_with(
@@ -167,7 +167,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'node': 'sf-2'})
 
     def test_create_namespace(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.create_namespace('testspace')
 
         self.mock_request.assert_called_with(
@@ -175,14 +175,14 @@ class ApiClientTestCase(testtools.TestCase):
             data={'namespace': 'testspace'})
 
     def test_get_namespace_keynames(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_namespace_keynames('testspace')
 
         self.mock_request.assert_called_with(
             'GET', 'http://localhost:13000/auth/namespaces/testspace/keys')
 
     def test_add_namespace_key(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.add_namespace_key('testspace', 'testkeyname', 'secretkey')
 
         self.mock_request.assert_called_with(
@@ -191,7 +191,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'key_name': 'testkeyname', 'key': 'secretkey'})
 
     def test_delete_namespace_key(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_namespace_key('testspace', 'keyname')
 
         self.mock_request.assert_called_with(
@@ -199,14 +199,14 @@ class ApiClientTestCase(testtools.TestCase):
             'http://localhost:13000/auth/namespaces/testspace/keys/keyname')
 
     def test_get_namespace_metadata(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_namespace_metadata('testspace')
 
         self.mock_request.assert_called_with(
             'GET', 'http://localhost:13000/auth/namespaces/testspace/metadata')
 
     def test_set_namespace_metadata_item(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.set_namespace_metadata_item('testspace', 'billy', 'bob')
 
         self.mock_request.assert_called_with(
@@ -215,7 +215,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'value': 'bob'})
 
     def test_delete_namespace_metadata_item(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_namespace_metadata_item('testspace', 'billy')
 
         self.mock_request.assert_called_with(
@@ -223,7 +223,7 @@ class ApiClientTestCase(testtools.TestCase):
             'http://localhost:13000/auth/namespaces/testspace/metadata/billy')
 
     def test_delete_instance_metadata_item(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_instance_metadata_item('instance1', 'petname')
 
         self.mock_request.assert_called_with(
@@ -231,35 +231,35 @@ class ApiClientTestCase(testtools.TestCase):
             'http://localhost:13000/instances/instance1/metadata/petname')
 
     def test_delete_network_metadata_item(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_network_metadata_item('net1', 'herd')
 
         self.mock_request.assert_called_with(
             'DELETE', 'http://localhost:13000/networks/net1/metadata/herd')
 
     def test_get_networks(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_networks()
 
         self.mock_request.assert_called_with(
             'GET', 'http://localhost:13000/networks', data={'all': False})
 
     def test_get_network(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_network('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'GET', 'http://localhost:13000/networks/notreallyauuid')
 
     def test_delete_network(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_network('notreallyauuid')
 
         self.mock_request.assert_called_with(
             'DELETE', 'http://localhost:13000/networks/notreallyauuid')
 
     def test_delete_all_networks(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_all_networks(None)
 
         self.mock_request.assert_called_with(
@@ -267,7 +267,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'confirm': True, 'namespace': None})
 
     def test_delete_all_networks_namespace(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.delete_all_networks('bobspace')
 
         self.mock_request.assert_called_with(
@@ -275,7 +275,7 @@ class ApiClientTestCase(testtools.TestCase):
             data={'confirm': True, 'namespace': 'bobspace'})
 
     def test_allocate_network(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.allocate_network('192.168.1.0/24', True, True, 'gerkin', None)
 
         self.mock_request.assert_called_with(
@@ -289,7 +289,7 @@ class ApiClientTestCase(testtools.TestCase):
             })
 
     def test_get_existing_locks(self):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         client.get_existing_locks()
 
         self.mock_request.assert_called_with(
@@ -317,7 +317,7 @@ class ApiClientGetNodesTestCase(testtools.TestCase):
     @mock.patch('shakenfist_client.apiclient.Client._request_url',
                 return_value=GetNodesMock())
     def test_get_nodes(self, mock_request):
-        client = apiclient.Client()
+        client = apiclient.Client(suppress_configuration_lookup=True)
         list(client.get_nodes())
 
         mock_request.assert_called_with(


### PR DESCRIPTION
Sometimes (like in CI) we want to override the configuration for
the cluster which is stored on disk. Add a flag to allow that and
then use it in the unit tests. Fixes #25.