### PR TITLE
Add missing column to interface header.

### DIFF
--- a/shakenfist_client/main.py
+++ b/shakenfist_client/main.py
@@ -777,7 +777,7 @@ def _show_instance(ctx, i, include_snapshots=False):
             _show_interface(ctx, interface)
 
     else:
-        print('iface,interface uuid,network uuid,macaddr,order,ipv4,floating')
+        print('iface,interface uuid,network uuid,macaddr,order,ipv4,floating,model')
         for interface in interfaces:
             _show_interface(ctx, interface)
 


### PR DESCRIPTION
We are missing "model" as a column heading in the interface listing
for instances when using "simple" output.