### PR TITLE
Only override values not provided.

### DIFF
--- a/Jenkinsfile-ubuntu-2004
+++ b/Jenkinsfile-ubuntu-2004
@@ -116,6 +116,14 @@ pipeline {
 
               echo "=============================="
               ssh -i /home/jenkins/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+                  ubuntu@$primary sudo cat /etc/sf/sfrc
+
+              echo "=============================="
+              ssh -i /home/jenkins/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+                  ubuntu@$primary sudo cat /etc/sf/shakenfist.json
+
+              echo "=============================="
+              ssh -i /home/jenkins/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
                   ubuntu@$primary sudo cat /var/log/syslog
 
               echo "=============================="

--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -84,18 +84,24 @@ class Client(object):
                 if os.path.exists(user_conf):
                     with open(user_conf) as f:
                         d = json.loads(f.read())
-                        namespace = d['namespace']
-                        key = d['key']
-                        base_url = d['apiurl']
+                        if not namespace:
+                            namespace = d['namespace']
+                        if not key:
+                            key = d['key']
+                        if not base_url:
+                            base_url = d['apiurl']
 
             if not base_url:
                 try:
                     if os.path.exists('/etc/sf/shakenfist.json'):
                         with open('/etc/sf/shakenfist.json') as f:
                             d = json.loads(f.read())
-                            namespace = d['namespace']
-                            key = d['key']
-                            base_url = d['apiurl']
+                            if not namespace:
+                                namespace = d['namespace']
+                            if not key:
+                                key = d['key']
+                            if not base_url:
+                                base_url = d['apiurl']
                 except IOError as e:
                     if e.errno != errno.EACCES:
                         raise


### PR DESCRIPTION
I realised while debugging CI tests that we should only use config file values for those you don't provide. For example, we should let you read base_url from a config file, but provide your own namespace and key.