### PR TITLE
Client side tweaks for specifying a namespace for network delete.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -460,8 +460,14 @@ class Client(object):
         r = self._request_url('GET', '/networks/' + network_uuid)
         return r.json()
 
-    def delete_network(self, network_uuid):
-        r = self._request_url('DELETE', '/networks/' + network_uuid)
+    def delete_network(self, network_uuid, namespace=None):
+        # Why pass a namespace when you're passing an exact UUID? The idea here
+        # is that it provides a consistent interface, but also a safety check
+        # against overly zealous loops deleting things.
+        data = None
+        if namespace:
+            data = {'namespace': namespace}
+        r = self._request_url('DELETE', '/networks/' + network_uuid, data=data)
         return r.json()
 
     def delete_all_networks(self, namespace, clean_wait=False):

--- a/shakenfist_client/commandline/network.py
+++ b/shakenfist_client/commandline/network.py
@@ -160,9 +160,10 @@ def network_events(ctx, network_uuid=None):
 
 @network.command(name='delete', help='Delete a network')
 @click.argument('network_uuid', type=click.STRING, autocompletion=util.get_networks)
+@click.option('--namespace', type=click.STRING)
 @click.pass_context
-def network_delete(ctx, network_uuid=None):
-    ctx.obj['CLIENT'].delete_network(network_uuid)
+def network_delete(ctx, network_uuid=None, namespace=None):
+    ctx.obj['CLIENT'].delete_network(network_uuid, namespace=None)
     if ctx.obj['OUTPUT'] == 'json':
         print('{}')
 

--- a/shakenfist_client/tests/test_client_apiclient.py
+++ b/shakenfist_client/tests/test_client_apiclient.py
@@ -288,7 +288,7 @@ class ApiClientTestCase(testtools.TestCase):
         client.delete_network('notreallyauuid')
 
         self.mock_request.assert_called_with(
-            'DELETE', '/networks/notreallyauuid')
+            'DELETE', '/networks/notreallyauuid', data=None)
 
     def test_delete_all_networks(self):
         client = apiclient.Client(suppress_configuration_lookup=True,


### PR DESCRIPTION
Depends on https://github.com/shakenfist/shakenfist/pull/978