### PR TITLE
Correctly display artifact indexes.

### DIFF
--- a/shakenfist_client/commandline/artifact.py
+++ b/shakenfist_client/commandline/artifact.py
@@ -69,17 +69,21 @@ def artifact_list(ctx, node=None):
         x = PrettyTable()
         x.field_names = ['uuid', 'type', 'source url', 'versions', 'state']
         for meta in artifacts:
+            versions = '%d of %d' % (len(meta.get('blobs', [])),
+                                     meta.get('index', 'unknown'))
             x.add_row([meta.get('uuid', ''), meta.get('artifact_type', ''),
-                       meta.get('source_url', ''), meta.get('index', ''),
+                       meta.get('source_url', ''), versions,
                        meta.get('state', '')])
         print(x)
 
     elif ctx.obj['OUTPUT'] == 'simple':
         print('uuid,type,source_url,versions,state')
         for meta in artifacts:
+            versions = '%d of %d' % (len(meta.get('blobs', [])),
+                                     meta.get('index', 'unknown'))
             print('%s,%s,%s,%s,%s' % (
                 meta.get('uuid', ''), meta.get('artifact_type', ''),
-                meta.get('source_url', ''), meta.get('index', ''),
+                meta.get('source_url', ''), versions,
                 meta.get('state', '')))
 
     elif ctx.obj['OUTPUT'] == 'json':


### PR DESCRIPTION
We were displaying the maximum index number, but not the number of
indexes actually present, which made me think the version cleanup
code wasn't working.