### PR TITLE
Autocomplete UUIDs by querying cluster

### DIFF
--- a/shakenfist_client/commandline/artifact.py
+++ b/shakenfist_client/commandline/artifact.py
@@ -16,7 +16,7 @@ def artifact():
 
 
 def _get_artifacts(ctx, args, incomplete):
-    choices = [a['uuid'] for a in ctx.obj['CLIENT'].get_artifacts()]
+    choices = [a['uuid'] for a in util.get_client(ctx).get_artifacts()]
     return [arg for arg in choices if arg.startswith(incomplete)]
 
 

--- a/shakenfist_client/commandline/instance.py
+++ b/shakenfist_client/commandline/instance.py
@@ -5,7 +5,6 @@ import json
 from prettytable import PrettyTable
 import sys
 
-
 from shakenfist_client import apiclient, util
 
 
@@ -15,7 +14,7 @@ def instance():
 
 
 def _get_instances(ctx, args, incomplete):
-    choices = [i['uuid'] for i in ctx.obj['CLIENT'].get_instances()]
+    choices = [i['uuid'] for i in util.get_client(ctx).get_instances()]
     return [arg for arg in choices if arg.startswith(incomplete)]
 
 
@@ -23,7 +22,7 @@ def _get_interfaces(ctx, instance):
     if instance.get('interfaces'):
         return instance['interfaces']
     try:
-        return ctx.obj['CLIENT'].get_instance_interfaces(instance['uuid'])
+        return util.get_client(ctx).get_instance_interfaces(instance['uuid'])
     except apiclient.ResourceNotFoundException:
         return []
 

--- a/shakenfist_client/commandline/label.py
+++ b/shakenfist_client/commandline/label.py
@@ -8,7 +8,7 @@ def label():
 
 @label.command(name='update',
                help=('Update a label to use a new blob.\n\n'
-                     'LABEL:     The name of the label to update\n'
+                     'LABEL:     The name of the label to update\n\n'
                      'BLOB_UUID: The UUID of the blob to use.'))
 @click.argument('label', type=click.STRING)
 @click.argument('blob_uuid', type=click.STRING)

--- a/shakenfist_client/commandline/namespace.py
+++ b/shakenfist_client/commandline/namespace.py
@@ -3,6 +3,8 @@ import json
 from prettytable import PrettyTable
 import sys
 
+from shakenfist_client import util
+
 
 def longest_str(d):
     if not d:
@@ -16,7 +18,7 @@ def namespace():
 
 
 def _get_namespaces(ctx, args, incomplete):
-    choices = ctx.obj['CLIENT'].get_namespaces()
+    choices = util.get_client(ctx).get_namespaces()
     return [arg for arg in choices if arg.startswith(incomplete)]
 
 

--- a/shakenfist_client/util.py
+++ b/shakenfist_client/util.py
@@ -1,4 +1,7 @@
+import os
 import sys
+
+from shakenfist_client import apiclient
 
 
 def filter_dict(d, allowed_keys):
@@ -41,6 +44,20 @@ def show_interface(ctx, interface, out=[]):
                  interface.get('floating', ''), interface['model']))
 
 
+def get_client(ctx):
+    client = None
+    if hasattr(ctx, 'obj') and ctx.obj:
+        client = ctx.obj.get('CLIENT')
+    if not client:
+        client = apiclient.Client(
+            namespace=os.environ.get('SHAKENFIST_NAMESPACE'),
+            key=os.environ.get('SHAKENFIST_KEY'),
+            base_url=os.environ.get('SHAKENFIST_API_URL', 'http://localhost:13000'),
+            async_strategy=os.environ.get('SHAKENFIST_ASYNC', 'pause')
+        )
+    return client
+
+
 def get_networks(ctx, args, incomplete):
-    choices = [i['uuid'] for i in ctx.obj['CLIENT'].get_networks()]
+    choices = [i['uuid'] for i in get_client(ctx).get_networks()]
     return [arg for arg in choices if arg.startswith(incomplete)]


### PR DESCRIPTION
The group cli() function is not called during autocomplete.
Therefore the client object is never stored in the context
object.

It's not immediately obvious how to initialise the object
during autocomplete, so this commit just checks whether the
client is initialised.