### PR TITLE
Rename the click autocompletion kwarg to shell_complete.

### DIFF
--- a/shakenfist_client/commandline/artifact.py
+++ b/shakenfist_client/commandline/artifact.py
@@ -94,7 +94,7 @@ def artifact_upload(ctx, name=None, source=None, source_url=None):
 
 
 @artifact.command(name='download', help='Download an artifact.')
-@click.argument('artifact_uuid', type=click.STRING, autocompletion=_get_artifacts)
+@click.argument('artifact_uuid', type=click.STRING, shell_complete=_get_artifacts)
 @click.argument('destination', type=click.Path(exists=False))
 @click.pass_context
 def artifact_download(ctx, artifact_uuid=None, destination=None):
@@ -160,7 +160,7 @@ def artifact_list(ctx, node=None):
 
 
 @artifact.command(name='show', help='Show an artifact')
-@click.argument('artifact_uuid', type=click.STRING, autocompletion=_get_artifacts)
+@click.argument('artifact_uuid', type=click.STRING, shell_complete=_get_artifacts)
 @click.pass_context
 def artifact_show(ctx, artifact_uuid=None):
     a = ctx.obj['CLIENT'].get_artifact(artifact_uuid)
@@ -207,7 +207,7 @@ def artifact_show(ctx, artifact_uuid=None):
 
 
 @artifact.command(name='versions', help='Show versions of an artifact')
-@click.argument('artifact_uuid', type=click.STRING, autocompletion=_get_artifacts)
+@click.argument('artifact_uuid', type=click.STRING, shell_complete=_get_artifacts)
 @click.pass_context
 def artifact_versions(ctx, artifact_uuid=None):
     vers = ctx.obj['CLIENT'].get_artifact_versions(artifact_uuid)
@@ -215,14 +215,14 @@ def artifact_versions(ctx, artifact_uuid=None):
 
 
 @artifact.command(name='delete', help='Delete an artifact')
-@click.argument('artifact_uuid', type=click.STRING, autocompletion=_get_artifacts)
+@click.argument('artifact_uuid', type=click.STRING, shell_complete=_get_artifacts)
 @click.pass_context
 def artifact_delete(ctx, artifact_uuid=None):
     ctx.obj['CLIENT'].delete_artifact(artifact_uuid)
 
 
 @artifact.command(name='delete-version', help='Delete an artifact version')
-@click.argument('artifact_uuid', type=click.STRING, autocompletion=_get_artifacts)
+@click.argument('artifact_uuid', type=click.STRING, shell_complete=_get_artifacts)
 @click.argument('version_id', type=click.INT)
 @click.pass_context
 def artifact_delete_version(ctx, artifact_uuid=None, version_id=0):
@@ -231,7 +231,7 @@ def artifact_delete_version(ctx, artifact_uuid=None, version_id=0):
 
 @artifact.command(name='max-versions',
                   help='Set the maximum number of versions of an artifact')
-@click.argument('artifact_uuid', type=click.STRING, autocompletion=_get_artifacts)
+@click.argument('artifact_uuid', type=click.STRING, shell_complete=_get_artifacts)
 @click.argument('max_versions', type=click.INT)
 @click.pass_context
 def max_versions(ctx, artifact_uuid, max_versions):

--- a/shakenfist_client/commandline/instance.py
+++ b/shakenfist_client/commandline/instance.py
@@ -240,7 +240,7 @@ def _show_instance(ctx, i, include_snapshots=False):
 
 
 @instance.command(name='show', help='Show an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.argument('snapshots', type=click.BOOL, default=False)
 @click.pass_context
 def instance_show(ctx, instance_uuid=None, snapshots=False):
@@ -271,10 +271,10 @@ order you specify them being significant."""))
 @click.argument('cpus', type=click.INT)
 @click.argument('memory', type=click.INT)
 @click.option('-n', '--network', type=click.STRING, multiple=True,
-              autocompletion=util.get_networks,
+              shell_complete=util.get_networks,
               help='A short form definition of a network to attach.')
 @click.option('-f', '--floated', type=click.STRING, multiple=True,
-              autocompletion=util.get_networks,
+              shell_complete=util.get_networks,
               help='As for --network, but with implied float of the interface.')
 @click.option('-N', '--networkspec', type=click.STRING, multiple=True,
               help='A long form "networkspec" definition of a network to attach.')
@@ -447,7 +447,7 @@ def instance_create(ctx, name=None, cpus=None, memory=None, network=None, floate
 
 
 @instance.command(name='delete', help='Delete an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.option('--namespace', type=click.STRING)
 @click.pass_context
 def instance_delete(ctx, instance_uuid=None, namespace=None):
@@ -469,7 +469,7 @@ def instance_delete_all(ctx, confirm=False, namespace=None):
 
 
 @instance.command(name='events', help='Display events for an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.pass_context
 def instance_events(ctx, instance_uuid=None):
     events = ctx.obj['CLIENT'].get_instance_events(instance_uuid)
@@ -501,7 +501,7 @@ def instance_events(ctx, instance_uuid=None):
 
 
 @instance.command(name='set-metadata', help='Set a metadata item')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.argument('key', type=click.STRING)
 @click.argument('value', type=click.STRING)
 @click.pass_context
@@ -516,7 +516,7 @@ def instance_set_metadata(ctx, instance_uuid=None, key=None, value=None):
 
 
 @instance.command(name='delete-metadata', help='Delete a metadata item')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.argument('key', type=click.STRING)
 @click.pass_context
 def instance_delete_metadata(ctx, instance_uuid=None, key=None):
@@ -526,7 +526,7 @@ def instance_delete_metadata(ctx, instance_uuid=None, key=None):
 
 
 @instance.command(name='reboot', help='Reboot instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.option('--hard/--soft', default=False)
 @click.pass_context
 def instance_reboot(ctx, instance_uuid=None, hard=False):
@@ -536,7 +536,7 @@ def instance_reboot(ctx, instance_uuid=None, hard=False):
 
 
 @instance.command(name='poweron', help='Power on an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.pass_context
 def instance_power_on(ctx, instance_uuid=None):
     ctx.obj['CLIENT'].power_on_instance(instance_uuid)
@@ -545,7 +545,7 @@ def instance_power_on(ctx, instance_uuid=None):
 
 
 @instance.command(name='poweroff', help='Power off an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.pass_context
 def instance_power_off(ctx, instance_uuid=None):
     ctx.obj['CLIENT'].power_off_instance(instance_uuid)
@@ -554,7 +554,7 @@ def instance_power_off(ctx, instance_uuid=None):
 
 
 @instance.command(name='pause', help='Pause an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.pass_context
 def instance_pause(ctx, instance_uuid=None):
     ctx.obj['CLIENT'].pause_instance(instance_uuid)
@@ -563,7 +563,7 @@ def instance_pause(ctx, instance_uuid=None):
 
 
 @instance.command(name='unpause', help='Unpause an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.pass_context
 def instance_unpause(ctx, instance_uuid=None):
     ctx.obj['CLIENT'].unpause_instance(instance_uuid)
@@ -572,7 +572,7 @@ def instance_unpause(ctx, instance_uuid=None):
 
 
 @instance.command(name='consoledata', help='Get console data for an instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.argument('length', type=click.INT, default=10240)
 @click.pass_context
 def instance_consoledata(ctx, instance_uuid=None, length=None):
@@ -580,14 +580,14 @@ def instance_consoledata(ctx, instance_uuid=None, length=None):
 
 
 @instance.command(name='consoledelete', help='Clear the console log for this instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.pass_context
 def instance_consoledelete(ctx, instance_uuid=None):
     ctx.obj['CLIENT'].delete_console_data(instance_uuid)
 
 
 @instance.command(name='snapshot', help='Snapshot instance')
-@click.argument('instance_uuid', type=click.STRING, autocompletion=_get_instances)
+@click.argument('instance_uuid', type=click.STRING, shell_complete=_get_instances)
 @click.option('-a', '--all', is_flag=True,
               help='Snapshot all disks, not just disk 0.')
 @click.option('-d', '--device', default=None,

--- a/shakenfist_client/commandline/interface.py
+++ b/shakenfist_client/commandline/interface.py
@@ -20,7 +20,7 @@ def _get_instance_interfaces(ctx, args, incomplete):
 
 @interface.command(name='show', help='Show an interface')
 @click.argument('interface_uuid', type=click.STRING,
-                autocompletion=_get_instance_interfaces)
+                shell_complete=_get_instance_interfaces)
 @click.pass_context
 def interface_show(ctx, interface_uuid=None):
     interface = ctx.obj['CLIENT'].get_interface(interface_uuid)
@@ -43,7 +43,7 @@ def interface_show(ctx, interface_uuid=None):
 @interface.command(name='float',
                    help='Add a floating IP to an interface')
 @click.argument('interface_uuid', type=click.STRING,
-                autocompletion=_get_instance_interfaces)
+                shell_complete=_get_instance_interfaces)
 @click.pass_context
 def interface_float(ctx, interface_uuid=None):
     ctx.obj['CLIENT'].float_interface(interface_uuid)
@@ -54,7 +54,7 @@ def interface_float(ctx, interface_uuid=None):
 @interface.command(name='defloat',
                    help='Remove a floating IP to an interface')
 @click.argument('interface_uuid', type=click.STRING,
-                autocompletion=_get_instance_interfaces)
+                shell_complete=_get_instance_interfaces)
 @click.pass_context
 def interface_defloat(ctx, interface_uuid=None):
     ctx.obj['CLIENT'].defloat_interface(interface_uuid)

--- a/shakenfist_client/commandline/namespace.py
+++ b/shakenfist_client/commandline/namespace.py
@@ -55,7 +55,7 @@ def namespace_create(ctx, namespace=None):
 @namespace.command(name='delete',
                    help=('delete a namespace.\n\n'
                          'NAMESPACE: The name of the namespace'))
-@click.argument('namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.argument('namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.pass_context
 def namespace_delete(ctx, namespace=None):
     ctx.obj['CLIENT'].delete_namespace(namespace)
@@ -101,7 +101,7 @@ def _show_namespace(ctx, namespace):
 
 
 @namespace.command(name='show', help='Show a namespace')
-@click.argument('namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.argument('namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.pass_context
 def namespace_show(ctx, namespace=None):
     _show_namespace(ctx, namespace)
@@ -110,7 +110,7 @@ def namespace_show(ctx, namespace=None):
 @namespace.command(name='clean',
                    help=('Clean (delete) namespace of all instances and networks'))
 @click.option('--confirm',  is_flag=True)
-@click.option('--namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.option('--namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.pass_context
 def namespace_clean(ctx, confirm=False, namespace=None):
     if not confirm:
@@ -126,7 +126,7 @@ def namespace_clean(ctx, confirm=False, namespace=None):
                          'NAMESPACE: The name of the namespace\n'
                          'KEY_NAME:  The unique name of the key\n'
                          'KEY:       The password for the namespace'))
-@click.argument('namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.argument('namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.argument('keyname', type=click.STRING)
 @click.argument('key', type=click.STRING)
 @click.pass_context
@@ -138,7 +138,7 @@ def namespace_add_key(ctx, namespace=None, keyname=None, key=None):
                    help=('delete a specific key from a namespace.\n\n'
                          'NAMESPACE: The name of the namespace\n'
                          'KEYNAME:   The name of the key'))
-@click.argument('namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.argument('namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.argument('keyname', type=click.STRING)
 @click.pass_context
 def namespace_delete_key(ctx, namespace=None, keyname=None):
@@ -146,7 +146,7 @@ def namespace_delete_key(ctx, namespace=None, keyname=None):
 
 
 @namespace.command(name='get-metadata', help='Get metadata items')
-@click.argument('namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.argument('namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.pass_context
 def namespace_get_metadata(ctx, namespace=None):
     metadata = ctx.obj['CLIENT'].get_namespace_metadata(namespace)
@@ -162,7 +162,7 @@ def namespace_get_metadata(ctx, namespace=None):
 
 
 @namespace.command(name='set-metadata', help='Set a metadata item')
-@click.argument('namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.argument('namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.argument('key', type=click.STRING)
 @click.argument('value', type=click.STRING)
 @click.pass_context
@@ -173,7 +173,7 @@ def namespace_set_metadata(ctx, namespace=None, key=None, value=None):
 
 
 @namespace.command(name='delete-metadata', help='Delete a metadata item')
-@click.argument('namespace', type=click.STRING, autocompletion=_get_namespaces)
+@click.argument('namespace', type=click.STRING, shell_complete=_get_namespaces)
 @click.argument('key', type=click.STRING)
 @click.pass_context
 def namespace_delete_metadata(ctx, namespace=None, key=None):

--- a/shakenfist_client/commandline/network.py
+++ b/shakenfist_client/commandline/network.py
@@ -86,7 +86,7 @@ def _show_network(ctx, n):
 
 
 @network.command(name='show', help='Show a network')
-@click.argument('network_uuid', type=click.STRING, autocompletion=util.get_networks)
+@click.argument('network_uuid', type=click.STRING, shell_complete=util.get_networks)
 @click.pass_context
 def network_show(ctx, network_uuid=None):
     _show_network(ctx, ctx.obj['CLIENT'].get_network(network_uuid))
@@ -127,7 +127,7 @@ def network_delete_all(ctx, confirm=False, namespace=None):
 
 
 @network.command(name='events', help='Display events for a network')
-@click.argument('network_uuid', type=click.STRING, autocompletion=util.get_networks)
+@click.argument('network_uuid', type=click.STRING, shell_complete=util.get_networks)
 @click.pass_context
 def network_events(ctx, network_uuid=None):
     events = ctx.obj['CLIENT'].get_network_events(network_uuid)
@@ -159,7 +159,7 @@ def network_events(ctx, network_uuid=None):
 
 
 @network.command(name='delete', help='Delete a network')
-@click.argument('network_uuid', type=click.STRING, autocompletion=util.get_networks)
+@click.argument('network_uuid', type=click.STRING, shell_complete=util.get_networks)
 @click.option('--namespace', type=click.STRING)
 @click.pass_context
 def network_delete(ctx, network_uuid=None, namespace=None):
@@ -170,7 +170,7 @@ def network_delete(ctx, network_uuid=None, namespace=None):
 
 @network.command(name='instances', help='List instances on a network')
 @click.argument('network_uuid',
-                type=click.STRING, autocompletion=util.get_networks)
+                type=click.STRING, shell_complete=util.get_networks)
 @click.pass_context
 def network_list_instances(ctx, network_uuid=None):
     interfaces = ctx.obj['CLIENT'].get_network_interfaces(network_uuid)
@@ -198,7 +198,7 @@ def network_list_instances(ctx, network_uuid=None):
 
 
 @network.command(name='set-metadata', help='Set a metadata item')
-@click.argument('network_uuid', type=click.STRING, autocompletion=util.get_networks)
+@click.argument('network_uuid', type=click.STRING, shell_complete=util.get_networks)
 @click.argument('key', type=click.STRING)
 @click.argument('value', type=click.STRING)
 @click.pass_context
@@ -209,7 +209,7 @@ def network_set_metadata(ctx, network_uuid=None, key=None, value=None):
 
 
 @network.command(name='delete-metadata', help='Delete a metadata item')
-@click.argument('network_uuid', type=click.STRING, autocompletion=util.get_networks)
+@click.argument('network_uuid', type=click.STRING, shell_complete=util.get_networks)
 @click.argument('key', type=click.STRING)
 @click.pass_context
 def network_delete_metadata(ctx, network_uuid=None, key=None, value=None):
@@ -219,7 +219,7 @@ def network_delete_metadata(ctx, network_uuid=None, key=None, value=None):
 
 
 @network.command(name='ping', help='Ping on this network')
-@click.argument('network_uuid', type=click.STRING, autocompletion=util.get_networks)
+@click.argument('network_uuid', type=click.STRING, shell_complete=util.get_networks)
 @click.argument('address', type=click.STRING)
 @click.pass_context
 def network_ping(ctx, network_uuid=None, address=None):


### PR DESCRIPTION
Per the click 8.1.0 release: "autocompletion parameter to
Command is renamed to shell_complete"