### PR TITLE
Handle route IP not being routed correctly on delete.

### DIFF
--- a/shakenfist_client/commandline/k3s.py
+++ b/shakenfist_client/commandline/k3s.py
@@ -424,7 +424,10 @@ def k3s_delete(ctx, name=None, namespace=None):
 
     # Free any routed ips
     for addr in md.get('routed_addresses', []):
-        ctx.obj['CLIENT'].unroute_network_address(md['node_network'], addr)
+        try:
+            ctx.obj['CLIENT'].unroute_network_address(md['node_network'], addr)
+        except apiclient.UnauthorizedException:
+            _emit_debug(ctx, '...Address %s was not routed to this network' % addr)
 
     # Delete node network
     if md['node_network']:


### PR DESCRIPTION
This is tracked as https://github.com/shakenfist/shakenfist/issues/2094 because I am concerned this indicates an underlying bug in the new routed IPs code.