### PR TITLE
Replace deprecated pkg_resources with importlib.metadata.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# Shaken Fist Python Client
+
+## Project Overview
+
+This is the official Python REST API client and command line interface for
+[Shaken Fist](https://github.com/shakenfist/shakenfist), a minimal cloud
+platform. The package provides both a programmatic API (`apiclient.py`) and a
+CLI tool (`sf-client`).
+
+## Architecture
+
+```
+shakenfist_client/
+├── main.py              # CLI entry point, plugin loading
+├── apiclient.py         # REST API client library
+├── util.py              # Shared utilities
+└── commandline/         # CLI subcommands
+    ├── admin.py         # Administrative commands
+    ├── ansible.py       # Ansible integration
+    ├── artifact.py      # Artifact management
+    ├── backup.py        # Backup operations
+    ├── blob.py          # Blob storage
+    ├── instance.py      # VM instance management
+    ├── interface.py     # Network interface management
+    ├── label.py         # Label management
+    ├── namespace.py     # Namespace management
+    ├── network.py       # Network management
+    └── node.py          # Cluster node management
+```
+
+### Key Components
+
+- **Client class** (`apiclient.py`): The main API client that handles
+  authentication, request/response processing, and async operation strategies.
+  Supports configuration from environment variables, `~/.shakenfist`, or
+  `/etc/sf/shakenfist.json`.
+
+- **CLI** (`main.py`): Built with Click, provides the `sf-client` command with
+  subcommands for managing all Shaken Fist resources.
+
+- **Plugin System**: Third-party packages can extend the CLI by registering
+  entry points in the `shakenfist_client.plugin` group.
+
+## Python Version Policy
+
+**The client maintains broad Python version compatibility (currently >=3.7)
+to support the widest possible range of client distributions.**
+
+This is intentionally more conservative than the Shaken Fist server itself,
+which can freely adopt modern Python features. The rationale:
+
+- The server runs on controlled infrastructure where we choose the OS
+- The client runs on user machines with varying distributions (including
+  enterprise Linux like RHEL 9 which ships Python 3.9)
+- Users should be able to manage their Shaken Fist clusters from any
+  reasonable workstation
+
+When adding new dependencies or using newer Python features, always check
+compatibility with the minimum supported version. Use conditional imports
+or backport packages where necessary.
+
+## Recent Changes
+
+### Plugin Loading Modernization (2026-01)
+
+Replaced deprecated `pkg_resources.iter_entry_points()` with
+`importlib.metadata.entry_points()`. This change was required because
+`pkg_resources` is slated for removal from setuptools.
+
+The implementation uses:
+- `importlib.metadata` (standard library in Python 3.8+)
+- `importlib-metadata` backport package for Python < 3.9
+
+The code handles API differences between Python versions:
+- Python 3.10+: Uses `entry_points().select(group=...)`
+- Python 3.9 and earlier: Uses `entry_points().get(group, [])`
+
+See `main.py` lines 7-10 and 137-147 for the implementation.
+
+## Development Notes
+
+### Testing
+
+Install test dependencies with:
+```bash
+pip install -e ".[test]"
+```
+
+Run tests with:
+```bash
+stestr run
+```
+
+### Building
+
+The package uses `setuptools_scm` for version management from git tags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "tqdm",                     # mit / mozilla
     "shakenfist-utilities",     # apache2
     "pyyaml",                   # mit
+    "importlib-metadata; python_version < '3.9'",  # apache2
 ]
 
 [project.urls]

--- a/shakenfist_client/main.py
+++ b/shakenfist_client/main.py
@@ -4,7 +4,10 @@ import logging
 import sys
 
 import click
-from pkg_resources import iter_entry_points
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
 from shakenfist_utilities import logs
 
 from shakenfist_client import apiclient
@@ -135,5 +138,13 @@ cli.add_command(version)
 
 
 # Load plugins
-for ep in iter_entry_points(group='shakenfist_client.plugin', name=None):
+eps = entry_points()
+# Python 3.10+
+if hasattr(eps, 'select'):
+    plugin_eps = eps.select(group='shakenfist_client.plugin')
+# Python 3.9 and earlier
+else:
+    plugin_eps = eps.get('shakenfist_client.plugin', [])
+
+for ep in plugin_eps:
     ep.load()(cli)


### PR DESCRIPTION
The pkg_resources package from setuptools is deprecated and slated for removal. This change migrates plugin loading to use the standard library importlib.metadata module instead.

For Python 3.9 and earlier, the importlib-metadata backport package is used. The code handles API differences between Python versions:
- Python 3.10+: Uses entry_points().select(group=...)
- Python 3.9 and earlier: Uses entry_points().get(group, [])

Also adds CLAUDE.md documenting the project architecture and the conservative Python version policy for the client.

Prompt: When I use sf-client, I now get frequent warning messages about pkg_resources being deprecated. What is the modern and correct way to provide plugins to sf-client in order to resolve this warning message?

Assisted-By: Claude Code