### PR TITLE
Fix infinite download in artifact download.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -1451,7 +1451,7 @@ def get_user_agent():
         try:
             from shakenfist_client import _version
             sf_version = VERSION_CACHE = _version.version
-        except ImportError as e:
+        except ImportError:
             sf_version = VERSION_CACHE = 'unreleased development version'
     else:
         sf_version = VERSION_CACHE

--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -839,6 +839,7 @@ class Client:
                 fetched += len(chunk)
                 yield chunk
 
+            offset += fetched
             if fetched < limit:
                 return
 

--- a/shakenfist_client/commandline/artifact.py
+++ b/shakenfist_client/commandline/artifact.py
@@ -116,6 +116,9 @@ def artifact_download(ctx, artifact_ref=None, destination=None):
                         bytes_in_attempt += received
                         total += received
 
+                        if total >= size:
+                            break
+
                     done = True
 
                 except urllib3.exceptions.NewConnectionError as e:


### PR DESCRIPTION
When the server supports blob-data-limit, get_blob_data() reads in 512MB chunks and stops when a chunk returns less than 512MB. If the server returns more data than expected (e.g. due to a server bug or offset handling issue), the download loop runs forever, filling disk. A 1.9GB artifact was observed downloading 37.9GB before being killed.

Stop the download when the received byte count reaches the expected artifact size.

Prompt: Fix sf-client artifact download running forever past the expected file size.


Assisted-By: Claude Code