### PR TITLE
Harden client console-data handling.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -1014,15 +1014,11 @@ class Client:
             d = {'length': length}
         else:
             d = {}
-        r = self._request_url('GET', url, data=d)
+        r = self._request_url('GET', url, data=d, response_body_is_binary=True)
 
-        out = r.text
-        if decode:
-            try:
-                out = out.decode(decode)
-            except Exception:
-                pass
-        return out
+        if decode is None:
+            return r.content
+        return r.content.decode(decode, errors='replace')
 
     def delete_console_data(self, instance_ref):
         url = '/instances/' + instance_ref + '/consoledata'

--- a/shakenfist_client/commandline/instance.py
+++ b/shakenfist_client/commandline/instance.py
@@ -623,7 +623,12 @@ def instance_unpause(ctx, instance_ref=None):
 @click.argument('length', type=click.INT, default=10240)
 @click.pass_context
 def instance_consoledata(ctx, instance_ref=None, length=None):
-    print(ctx.obj['CLIENT'].get_console_data(instance_ref, length=length))
+    data = ctx.obj['CLIENT'].get_console_data(
+        instance_ref, length=length, decode=None)
+    if sys.stdout.isatty():
+        data = util.sanitize_terminal_bytes(data)
+    sys.stdout.buffer.write(data)
+    sys.stdout.flush()
 
 
 @instance.command(name='consoledelete', help='Clear the console log for this instance')

--- a/shakenfist_client/tests/test_client_apiclient.py
+++ b/shakenfist_client/tests/test_client_apiclient.py
@@ -348,6 +348,37 @@ class ApiClientTestCase(testtools.TestCase):
         self.mock_request.assert_called_with(
             'GET', '/admin/locks')
 
+    def test_get_console_data_returns_bytes_when_decode_none(self):
+        # 1000 raw bytes including a 3-byte UTF-8 ellipsis. Decoding as text
+        # would yield 998 characters; with decode=None we want the raw bytes.
+        raw = b'a' * 997 + '…'.encode('utf-8')
+        self.assertEqual(1000, len(raw))
+        self.mock_request.return_value = mock.Mock(content=raw)
+
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        out = client.get_console_data('uuid', length=1000, decode=None)
+
+        self.assertEqual(raw, out)
+        self.assertEqual(1000, len(out))
+        self.mock_request.assert_called_with(
+            'GET', '/instances/uuid/consoledata',
+            data={'length': 1000}, response_body_is_binary=True)
+
+    def test_get_console_data_decodes_with_replacement(self):
+        # Invalid byte 0x80 in the middle should not raise; the decoder is
+        # asked to replace it.
+        raw = b'hello\x80world'
+        self.mock_request.return_value = mock.Mock(content=raw)
+
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        out = client.get_console_data('uuid', length=100)
+
+        self.assertIsInstance(out, str)
+        self.assertIn('hello', out)
+        self.assertIn('world', out)
+
 
 class GetNodesMock():
     def json(self):

--- a/shakenfist_client/tests/test_client_commandline_instance.py
+++ b/shakenfist_client/tests/test_client_commandline_instance.py
@@ -1,0 +1,70 @@
+import io
+from unittest import mock
+
+import testtools
+from click.testing import CliRunner
+
+from shakenfist_client.commandline import instance as instance_cmd
+
+
+class ConsoleDataCommandTestCase(testtools.TestCase):
+    """Tests for ``sf-client instance consoledata``.
+
+    CliRunner replaces ``sys.stdout`` for output capture, which would
+    override any patch we apply to the real ``sys.stdout.isatty``. To
+    decouple the tests from the runner's stream, we instead replace the
+    ``sys`` *module reference* inside the command module with a fake; the
+    production code reaches stdout via that reference, so it sees what we
+    want it to see regardless of what the runner does to the real stdout.
+    """
+
+    def _fake_sys(self, isatty, buffer):
+        fake = mock.MagicMock()
+        fake.stdout.isatty.return_value = isatty
+        fake.stdout.buffer = buffer
+        return fake
+
+    def _invoke(self, mock_client, isatty):
+        buffer = io.BytesIO()
+        with mock.patch.object(
+                instance_cmd, 'sys', self._fake_sys(isatty, buffer)):
+            runner = CliRunner()
+            result = runner.invoke(
+                instance_cmd.instance,
+                ['consoledata', 'inst-ref', '100'],
+                obj={'CLIENT': mock_client, 'OUTPUT': 'pretty'},
+                catch_exceptions=False)
+        return result, buffer.getvalue()
+
+    def test_requests_raw_bytes_via_decode_none(self):
+        client = mock.Mock()
+        client.get_console_data.return_value = b'plain bytes'
+
+        self._invoke(client, isatty=False)
+
+        client.get_console_data.assert_called_once_with(
+            'inst-ref', length=100, decode=None)
+
+    def test_non_tty_writes_raw_bytes_unsanitized(self):
+        # Bytes containing a CSI colour sequence and a NUL byte must be
+        # written byte-for-byte when stdout is a pipe -- preserving
+        # fidelity for `sf-client ... consoledata > file`.
+        client = mock.Mock()
+        raw = b'\x1b[31mred\x1b[0m\x00'
+        client.get_console_data.return_value = raw
+
+        result, written = self._invoke(client, isatty=False)
+
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual(raw, written)
+
+    def test_tty_strips_escape_and_control_bytes(self):
+        client = mock.Mock()
+        client.get_console_data.return_value = (
+            b'\x1b[31mred\x1b[0m\x00 ok\n')
+
+        result, written = self._invoke(client, isatty=True)
+
+        self.assertEqual(0, result.exit_code)
+        # CSI sequences and NUL stripped; printable text and newline kept.
+        self.assertEqual(b'red ok\n', written)

--- a/shakenfist_client/tests/test_client_util.py
+++ b/shakenfist_client/tests/test_client_util.py
@@ -1,0 +1,58 @@
+import testtools
+
+from shakenfist_client import util
+
+
+class SanitizeTerminalBytesTestCase(testtools.TestCase):
+    def test_plain_text_is_unchanged(self):
+        self.assertEqual(
+            b'hello world\n',
+            util.sanitize_terminal_bytes(b'hello world\n'))
+
+    def test_tabs_and_newlines_preserved(self):
+        self.assertEqual(
+            b'a\tb\nc\rd',
+            util.sanitize_terminal_bytes(b'a\tb\nc\rd'))
+
+    def test_csi_color_sequence_stripped(self):
+        self.assertEqual(
+            b'OK Finished',
+            util.sanitize_terminal_bytes(b'\x1b[0;32mOK\x1b[0m Finished'))
+
+    def test_osc_set_window_title_stripped(self):
+        # OSC 0;title BEL — used to set the terminal window title.
+        self.assertEqual(
+            b'after',
+            util.sanitize_terminal_bytes(b'\x1b]0;pwn\x07after'))
+
+    def test_osc_terminated_by_st_stripped(self):
+        self.assertEqual(
+            b'after',
+            util.sanitize_terminal_bytes(b'\x1b]0;pwn\x1b\\after'))
+
+    def test_dcs_stripped(self):
+        self.assertEqual(
+            b'tail',
+            util.sanitize_terminal_bytes(b'\x1bPpayload\x1b\\tail'))
+
+    def test_lone_escape_dropped(self):
+        # ESC followed by a single Fe byte (e.g. ESC c — full reset).
+        self.assertEqual(
+            b'after',
+            util.sanitize_terminal_bytes(b'\x1bcafter'))
+
+    def test_other_c0_controls_stripped(self):
+        # NUL, BS, VT, FF, SO, SI, etc. removed; \t \n \r preserved (above).
+        self.assertEqual(
+            b'ab',
+            util.sanitize_terminal_bytes(b'a\x00\x01\x02\x07\x08\x0bb'))
+
+    def test_c1_controls_stripped(self):
+        self.assertEqual(
+            b'ab',
+            util.sanitize_terminal_bytes(b'a\x80\x9bb'))
+
+    def test_del_stripped(self):
+        self.assertEqual(
+            b'ab',
+            util.sanitize_terminal_bytes(b'a\x7fb'))

--- a/shakenfist_client/tests/test_client_util.py
+++ b/shakenfist_client/tests/test_client_util.py
@@ -56,3 +56,16 @@ class SanitizeTerminalBytesTestCase(testtools.TestCase):
         self.assertEqual(
             b'ab',
             util.sanitize_terminal_bytes(b'a\x7fb'))
+
+    def test_empty_input(self):
+        self.assertEqual(b'', util.sanitize_terminal_bytes(b''))
+
+    def test_large_input_completes(self):
+        # Smoke test for ReDoS resistance. The patterns use disjoint
+        # character classes and bounded `[^\x07\x1b]*` / `[^\x1b]*` runs,
+        # so backtracking is linear; verify a 1 MB worst-case-shaped input
+        # finishes and produces the expected output.
+        chunk = b'\x1b[' + b'0;' * 50 + b'm' + b'a'
+        payload = chunk * 10000
+        self.assertGreater(len(payload), 1_000_000)
+        self.assertEqual(b'a' * 10000, util.sanitize_terminal_bytes(payload))

--- a/shakenfist_client/util.py
+++ b/shakenfist_client/util.py
@@ -1,11 +1,39 @@
 import hashlib
 import os
+import re
 import sys
 import time
 
 from tqdm import tqdm
 
 from shakenfist_client import apiclient
+
+
+# Strips terminal escape sequences (CSI, OSC, DCS, SOS, PM, APC, single-char
+# Fe sequences) and C0/C1 control bytes other than \t \n \r. Used when
+# rendering attacker-controlled bytes (e.g. VM console output) to a TTY,
+# where untrusted escape sequences could rewrite the user's display, set
+# the window title, or trigger paste-buffer manipulation.
+_ANSI_ESCAPE_RE = re.compile(
+    rb'\x1b(?:'
+    rb'\[[0-?]*[ -/]*[@-~]'        # CSI
+    rb'|\][^\x07\x1b]*(?:\x07|\x1b\\)'  # OSC, terminated by BEL or ST
+    rb'|[PX^_][^\x1b]*\x1b\\'      # DCS, SOS, PM, APC, terminated by ST
+    rb'|[ -/]*[0-~]'               # nF (intermediate*+final), Fp/Fe/Fs single
+    rb')')
+
+_C0_C1_STRIP_RE = re.compile(rb'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]')
+
+
+def sanitize_terminal_bytes(data):
+    """Remove escape sequences and unsafe control bytes from `data`.
+
+    Accepts and returns bytes. Tabs, newlines, and carriage returns are
+    preserved.
+    """
+    data = _ANSI_ESCAPE_RE.sub(b'', data)
+    data = _C0_C1_STRIP_RE.sub(b'', data)
+    return data
 
 
 def filter_dict(d, allowed_keys):


### PR DESCRIPTION
``get_console_data`` returned ``r.text`` unconditionally, ignoring its own ``decode`` parameter (the ``out.decode`` call was a no-op on a string and the resulting exception was silently swallowed). This had three consequences:

1. ``decode=None`` callers got a unicode string rather than the raw bytes they asked for, so multi-byte UTF-8 sequences in the console (e.g. systemd's ``…`` truncation marker on Debian 12) caused the byte count to drop below the requested length. The functional CI test ``test_console_log`` failed with ``Console response was not 1000 characters (998 instead)`` for exactly this reason -- one ``…`` is 3 bytes but 1 character.

2. The library logged debug output by attempting ``json.loads(r.text)`` on the response. Because ``response_body_is_binary`` was not set, console bytes were fed to the JSON parser. Currently exceptions are swallowed and there is no exploitable path, but passing attacker-controlled bytes through a JSON parser is the wrong shape and any caller who later trusts ``json.loads(client.get_console_data(...))`` walks straight into it.

3. The CLI ``instance consoledata`` subcommand ``print()``'d the decoded text directly to the user's terminal. A malicious tenant can write CSI/OSC/DCS escape sequences to ``/dev/console``; when an admin later runs ``sf-client instance consoledata`` those sequences run in the admin's terminal and can rewrite the prompt, set the window title, or (on terminals that honour OSC 52 / paste-bracketing tricks) manipulate the paste buffer.

This change:

* ``get_console_data`` operates on ``r.content`` (raw bytes from requests). When ``decode`` is ``None`` it returns the bytes unchanged; otherwise it decodes with ``errors='replace'`` so an invalid byte cannot raise. ``response_body_is_binary=True`` is now passed to ``_request_url`` so the debug log path stops trying to JSON-parse console output.
* ``instance consoledata`` fetches raw bytes (``decode=None``), runs them through ``util.sanitize_terminal_bytes`` when stdout is a TTY, and writes via ``sys.stdout.buffer.write`` so a redirected pipe gets a byte-faithful copy.
* ``util.sanitize_terminal_bytes`` strips CSI, OSC (BEL- or ST-terminated), DCS/SOS/PM/APC, single-char Fp/Fe/Fs and nF escape sequences plus C0 (excluding ``\t \n \r``), C1, and DEL bytes.

Tests cover round-tripping 1000 raw bytes including a 3-byte ``…`` (the exact Debian 12 failure case), graceful decoding of invalid UTF-8, and ten sanitiser cases (plain text, tabs/newlines preserved, CSI colour, OSC window-title with both BEL and ST terminators, DCS, ESC c (RIS), C0/C1/DEL stripped).

Prompt: While investigating a Debian 12 functional CI failure on ``test_console_log`` (998 instead of 1000 bytes), trace the bug all the way through. The immediate cause is ``r.text`` collapsing UTF-8 multi-byte sequences, but I asked whether there was a broader injection
concern -- specifically whether console bytes flowing through a JSON parser, or being printed to a terminal, were exploitable. They are not currently exploitable, but the shape is wrong on both counts. Fix all three issues together: raw bytes from the API, no JSON-parse of console bytes in debug logging, terminal-escape sanitisation in the CLI when writing to a TTY. Land on a fresh branch off ``develop`` (a sibling worktree at ``client-wt-consoledata-fixes``) so the unrelated
``renovate-widen`` branch is not disturbed.


Assisted-By: Claude Opus 4.7 (1M context, low effort) <noreply@anthropic.com>