### PR TITLE
Add get_cluster_resources() for the /admin/resources endpoint.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -1296,6 +1296,14 @@ class Client:
         r = self._request_url('GET', '/admin/cacert')
         return r.text
 
+    def get_cluster_resources(self):
+        if not self.check_capability('cluster-resources'):
+            raise IncapableException(
+                'The API server version you are talking to does not support '
+                'reporting cluster resources.')
+        r = self._request_url('GET', '/admin/resources')
+        return r.json()
+
     # The following methods are convenience wrappers around methods above.
     def await_instance_create(self, instance_uuid, timeout=600):
         # Wait up to 10 minutes for the instance to be created. On a slow


### PR DESCRIPTION
The server's AdminResourcesEndpoint (GET /admin/resources) reports which hypervisors the scheduler currently considers schedulable. Add a client method to fetch it, mirroring get_cluster_cacert(): it guards on the "cluster-resources" capability and raises IncapableException against an older server that does not expose the endpoint.

This is used by the Shaken Fist CI readiness gate (to wait for a schedulable node before running functional tests) and by a new cluster_ci regression test, both on the shakenfist side. Landing this on develop first means those changes have the method available when their CI builds the client locally.

Prompt: Mikal asked to update client-python with the client side of the newly registered cluster-resources endpoint, on a branch off a freshly pulled develop, so it can land ahead of the shakenfist changes.


Assisted-By: Claude Opus 4.8 (1M context, high effort)