### PR TITLE
Fix the automated code formatting workflow.

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -37,20 +37,6 @@ jobs:
           path: client-python
           fetch-depth: 0
 
-      - name: Checkout shakenfist
-        uses: actions/checkout@v7
-        with:
-          repository: shakenfist/shakenfist
-          path: shakenfist
-          fetch-depth: 0
-
-      - name: Checkout the actions repository
-        uses: actions/checkout@v7
-        with:
-          repository: shakenfist/actions
-          path: actions
-          fetch-depth: 0
-
       - name: Install the github command line
         run: |
           bash ${GITHUB_WORKSPACE}/client-python/tools/install-gh-cli.sh
@@ -58,18 +44,15 @@ jobs:
       - name: Install formatting tools in a venv
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=-1 -o Dpkg::Options::="--force-confold" -y \
-            install git python3-cffi python3-dev python3-grpcio python3-pip python3-venv python3-wheel
+            install git python3-pip python3-venv
 
           python3 -m venv --system-site-packages ${RUNNER_TEMP}/venv
-          cd ${GITHUB_WORKSPACE}/shakenfist
-          ${RUNNER_TEMP}/venv/bin/pip install uv
-          ${RUNNER_TEMP}/venv/bin/uv pip install -r pyproject.toml
-          ${RUNNER_TEMP}/venv/bin/uv pip install pyupgrade reorder-python-imports
+          ${RUNNER_TEMP}/venv/bin/pip install pyupgrade reorder-python-imports
 
       - name: Scan for obsolete syntax
         env:
           GITHUB_TOKEN: ${{ secrets.DEPENDENCIES_TOKEN }}
         run: |
-          cd ${GITHUB_WORKSPACE}/shakenfist
+          cd ${GITHUB_WORKSPACE}/client-python
           . ${RUNNER_TEMP}/venv/bin/activate
-          ${GITHUB_WORKSPACE}/actions/tools/ci_code_formatting.sh 38 --skip-grpc
+          ./tools/ci_code_formatting.sh 37

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -353,8 +353,6 @@ jobs:
           if-no-files-found: error
           path: /srv/github/artifacts/bundle.zip
 
-          path: /srv/github/artifacts/bundle.zip
-
   automated_reviewer:
     name: "Automated reviewer"
     permissions:

--- a/tools/ci_code_formatting.sh
+++ b/tools/ci_code_formatting.sh
@@ -30,7 +30,7 @@ for file in $( find . -type f -name "*.py" \
     # reorder imports
     out=$( "${RUNNER_TEMP}/venv/bin/reorder-python-imports" \
         "--py${1}-plus" \
-        --application-directories=.:shakenfist \
+        --application-directories=. \
         --exit-zero-even-if-changed "${file}" 2>&1 || true )
     rewrites=$( echo "${out}" | grep -c "Reordering" || true )
     if [ "${rewrites}" -gt 0 ]; then


### PR DESCRIPTION
The nightly code-formatters job has failed since the shakenfist pyproject.toml migration: uv was invoked by path from inside a venv, but uv only installs into an activated environment (VIRTUAL_ENV) or a local .venv, so it aborted with "No virtual environment found".

While fixing this it became clear the job had been mistargeted since 331e2e2: the scan step ran in the shakenfist checkout, so this job was scanning the server repository and never formatting client-python at all. The shared actions-repo script it called also no-ops due to an argument indexing bug, and the "38" minimum version conflicted with this client's >=3.7 support policy.

Rework the workflow to check out only client-python, install just pyupgrade and reorder-python-imports with pip (no uv, no shakenfist dependencies), and run the repository's own
tools/ci_code_formatting.sh with a 3.7 floor. Fix the stale shakenfist application-directories reference in that script, and remove a duplicated upload-artifact path key in functional-tests.yml that was failing actionlint.

Prompt: Resolve the broken automated formatting workflow (GitHub Actions run 28764813648), where the nightly code-formatters job fails to install its tooling.