### PR TITLE
Deploy smoke clusters via the reusable workflow.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -81,6 +81,13 @@ jobs:
           . /tmp/venv-test/bin/activate
           tox -epy3
 
+  # A smoke-tier Shaken Fist cluster deployed via the reusable
+  # smoke-cluster workflow in shakenfist/actions. The deploy builds the
+  # client wheel from THIS repository's PR checkout (and the server from
+  # shakenfist develop), then runs the standard smoke suite -- just enough
+  # of a cluster to determine a client change has not completely broken
+  # things. Full-depth cluster testing lives in the shakenfist repo's own
+  # CI. See remove-primary phase 8 in the shakenfist repo's docs/plans.
   functional_matrix:
     name: "${{ matrix.os.description }}"
     needs: sanity_checks
@@ -91,267 +98,15 @@ jobs:
           {
             description: 'debian 12 single machine',
             job_name: 'debian-12-localhost',
-            base_image: 'sf://label/ci-images/debian-12',
-            base_image_user: 'debian',
-            topology: 'localhost',
-            stestr_config: 'cluster-ci.conf',
-            concurrency: 3
           },
         ]
-    runs-on: [self-hosted, vm]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os.job_name }}
-      cancel-in-progress: true
-
-    steps:
-      - name: Log matrix details
-        run: |
-          echo "job_name: ${{ matrix.os.job_name }}"
-          echo "base_image: ${{ matrix.os.base_image }}"
-          echo "base_image_user: ${{ matrix.os.base_image_user }}"
-          echo "topology: ${{ matrix.os.topology }}"
-          echo "concurrency: ${{ matrix.os.concurrency }}"
-
-      - name: Setup test environment
-        uses: shakenfist/actions/setup-test-environment@main
-
-      - name: Build infrastructure
-        run: |
-          cd ${GITHUB_WORKSPACE}/actions
-          ansible-playbook -i /home/debian/ansible-hosts \
-              --extra-vars "identifier=${SHAKENFIST_NAMESPACE} source_path=${GITHUB_WORKSPACE} \
-              base_image=${{ matrix.os.base_image }} base_image_user=${{ matrix.os.base_image_user }}" \
-              ansible/ci-topology-${{ matrix.os.topology }}.yml
-
-          if [ "${{ matrix.os.topology }}" == "localhost" ]; then
-            echo "UPLOAD_TARGET=10.0.0.10" >> $GITHUB_ENV
-          else
-            nodes=(10.0.0.20 10.0.0.21 10.0.0.22 10.0.0.23 10.0.0.24)
-            random_index=$(( RANDOM % 5 ))
-            echo "UPLOAD_TARGET=${nodes[$random_index]}" >> $GITHUB_ENV
-          fi
-
-      - name: Log environmental configuration
-        run: |
-          echo "## ci-environment.sh"
-          cat ${GITHUB_WORKSPACE}/ci-environment.sh
-          echo
-          echo "## Environment variables"
-          echo "SF_HEAD_SHA = ${SF_HEAD_SHA}"
-          echo "SHAKENFIST_NAMESPACE = ${SHAKENFIST_NAMESPACE}"
-          echo "UPLOAD_TARGET = ${UPLOAD_TARGET}"
-
-      - name: Copy CI tools to primary
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          cd ${GITHUB_WORKSPACE}/actions
-          scp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null -rp tools \
-              ${{ matrix.os.base_image_user }}@${primary}:.
-
-          echo ""
-          echo "Copied tools:"
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "ls tools"
-
-      - name: Log github actions buffering status
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          cd ${GITHUB_WORKSPACE}/actions
-          tools/run_remote ${primary} python3 tools/buffer.py
-
-      - name: Run getsf installer on primary
-        timeout-minutes: 30
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} /tmp/getsf-wrapper
-          echo ""
-          echo ""
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
-              'sudo rm /etc/apache2/sites-enabled/*; sudo a2ensite sf-example.conf; sudo apachectl graceful'
-
-      - name: Wait for API to start answering
-        run: |
-          set +e
-
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} 'sudo chmod ugo+r /etc/sf/* /var/log/syslog'
-
-          count=0
-          while [ $count -lt 60 ]
-          do
-            ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} '. /etc/sf/sfrc; sf-client instance list'
-            if [ $? == 0 ]; then
-              exit 0
-            fi
-
-            count=$(( $count + 1 ))
-            sleep 5
-          done
-
-          exit 1
-
-      - name: Import cached images
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-
-          setup="export PATH=$PATH:/srv/shakenfist/venv/bin;"
-          setup="${setup} . /etc/sf/sfrc;"
-          setup="${setup} export SHAKENFIST_API_URL=http://localhost:13000;"
-          setup="${setup} sf-client artifact upload"
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${UPLOAD_TARGET} \
-              "${setup} debian-12 /srv/ci/debian:12 --shared --no-checksum"
-
-      - name: Make the traces directory
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "sudo mkdir -p /srv/ci/traces; sudo chown -R ${{ matrix.os.base_image_user }}:${{ matrix.os.base_image_user }} /srv/ci/traces"
-
-      - name: Run functional tests
-        timeout-minutes: 120
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${GITHUB_WORKSPACE}/shakenfist \
-              ${{ matrix.os.base_image_user }}@${primary}:shakenfist
-          scp -rp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null \
-              ${GITHUB_WORKSPACE}/client-python \
-              ${{ matrix.os.base_image_user }}@${primary}:client-python
-
-          script="cd shakenfist/;"
-          script="${script} . /etc/sf/sfrc;"
-
-          script="${script} python3 -mvenv /tmp/functests;"
-          script="${script} . /tmp/functests/bin/activate;"
-          script="${script} pip3 install -U uv;"
-          script="${script} uv pip install -U -r pyproject.toml --all-extras;"
-          script="${script} echo -e '\n\nvenv pip after packages:\n';"
-          script="${script} pip3 list;"
-          script="${script} echo -e '\n---\n';"
-
-          script="${script} echo -e '\n\nInstall client-python:\n';"
-          script="${script} cd ~/client-python;"
-          script="${script} pip3 install .;"
-
-          script="${script} cd ~/shakenfist/shakenfist/deploy/;"
-          script="${script} set -e;"
-          script="${script} stestr run --config ${{ matrix.os.stestr_config }} --concurrency=${{ matrix.os.concurrency}};"
-
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} "${script}"
-
-      - name: List slowest tests
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
-              "cd shakenfist/shakenfist/deploy; stestr slowest || true"
-
-      - name: List failing tests
-        if: failure()
-        id: failures
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-
-          echo "Gathering list of failed tests..."
-          touch ${GITHUB_WORKSPACE}/failed
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} \
-              "cd shakenfist/shakenfist/deploy; stestr failing || true" > ${GITHUB_WORKSPACE}/failed
-          echo
-
-          failed=$(cat ${GITHUB_WORKSPACE}/failed | egrep "^FAIL: " | \
-              sed -z 's/FAIL: shakenfist_ci\.//g;s/\n/, /g;s/, $/\n/')
-
-          echo "Failed tests:"
-          cat ${GITHUB_WORKSPACE}/failed
-          echo
-
-          echo "failures<<EOF" >> ${GITHUB_OUTPUT}
-          echo "${failed}" >> ${GITHUB_OUTPUT}
-          echo "EOF" >> ${GITHUB_OUTPUT}
-          echo "GITHUB_OUTPUT is:"
-          cat ${GITHUB_OUTPUT}
-
-      - name: Check logs
-        if: always()
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          cd ${GITHUB_WORKSPACE}/actions
-          tools/run_remote ${primary} "sudo bash tools/ci_log_checks.sh develop ${{ matrix.os.job_name }}"
-
-      # On Ubuntu 22.04 the cleaner is rated a CPU hog because of etcd cleanup
-      # cost. That's not really something we can control, so just ignore the CPU
-      # usage of that process instead.
-      - name: Check SF process CPU usage
-        if: always()
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          ssh -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary} '. /etc/sf/sfrc; sf-client node cpuhogs -t 1.25 --ignore sf_cleaner'
-
-      - name: Check for reasonable data rates
-        timeout-minutes: 5
-        if: always()
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          cd ${GITHUB_WORKSPACE}/actions
-          tools/run_remote ${primary} "sudo bash tools/ci_event_checks.sh develop"
-
-      - name: Fetch and tweak inventory
-        if: always()
-        run: |
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          scp -i /srv/github/id_ci -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-              ${{ matrix.os.base_image_user }}@${primary}:/etc/sf/inventory.yaml /srv/github/
-          sed -i 's|/root/.ssh|/home/debian/.ssh|g' /srv/github/inventory.yaml
-
-          echo "====="
-          cat /srv/github/inventory.yaml
-
-      - name: Gather logs
-        if: always()
-        run: |
-          set -x
-
-          # Fetch unit test tracing. Sometimes this isn't present if we failed
-          # super early in the CI job.
-          . ${GITHUB_WORKSPACE}/ci-environment.sh
-          mkdir -p /srv/github/bundle/
-          scp -i /srv/github/id_ci -o StrictHostKeyChecking=no \
-              -o UserKnownHostsFile=/dev/null -rp \
-              ${{ matrix.os.base_image_user }}@${primary}:/srv/ci/traces \
-              /srv/github/bundle/ || true
-
-          # We need the ssh key in the place ansible expects it to be, which isn't
-          # true on the CI worker node.
-          cp /srv/github/id_ci /home/debian/.ssh/id_rsa
-          cp /srv/github/id_ci.pub /home/debian/.ssh/id_rsa.pub
-
-          ansible-playbook -i /srv/github/inventory.yaml \
-              --extra-vars "base_image_user=${{ matrix.os.base_image_user }} \
-              ansible_ssh_common_args='-o StrictHostKeyChecking=no'" \
-              ${GITHUB_WORKSPACE}/actions/ansible/ci-gather-logs.yml
-
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: bundle-functional-cluster-${{ matrix.os.job_name }}
-          retention-days: 90
-          if-no-files-found: error
-          path: /srv/github/artifacts/bundle.zip
+    uses: shakenfist/actions/.github/workflows/smoke-cluster.yml@main
+    secrets: inherit
+    with:
+      component: client-python
+      component_ref: ${{ github.sha }}
+      tier: smoke
+      concurrency_key: ${{ matrix.os.job_name }}
 
   automated_reviewer:
     name: "Automated reviewer"


### PR DESCRIPTION
The functional_matrix job was a getsf-era copy of shakenfist's old smoke CI, and has been hard-broken since shakenfist deleted the getsf installer chain (the topology playbooks stopped writing the wrapper the job invoked). Replace its ~270 lines with a call to the reusable smoke-cluster workflow in shakenfist/actions: the deploy builds the client wheel from this repository's PR checkout against a shakenfist develop server, runs the standard smoke suite, and gathers logs -- just enough of a cluster to determine a client change has not completely broken things. Full-depth cluster testing lives in the shakenfist repo's own CI.

Note for merging: the reported check context changes from "debian 12 single machine" to "debian 12 single machine / Smoke tests (collection)", so the repository's required status check needs updating at the same time as this merges.

This is phase 8 step 3 of shakenfist's remove-primary plan.

Prompt: Implement phase 8; this is the client-python adoption of the reusable smoke-cluster workflow.


Assisted-By: Claude Opus 4.8 (200K context, high effort)