### PR TITLE
Read SHAKENFIST_* env vars in apiclient.Client.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -169,8 +169,21 @@ class Client:
 
         if not suppress_configuration_lookup:
             # Where do we find authentication details? First off, we try command line
-            # flags; then environment variables (thanks for doing this for free click);
-            # ~/.shakenfist (which is a JSON file); and finally /etc/sf/shakenfist.json.
+            # flags; then environment variables; ~/.shakenfist (which is a JSON file);
+            # and finally /etc/sf/shakenfist.json. click reads the environment
+            # variables for free in the CLI, but we must also do it here so that
+            # other library callers (the ansible collection for example) behave the
+            # same way as the CLI.
+            if not base_url:
+                LOG.debug('Testing environment variables')
+                base_url = os.environ.get('SHAKENFIST_API_URL')
+                if base_url:
+                    LOG.debug('Loading configuration from environment variables')
+                    if not namespace:
+                        namespace = os.environ.get('SHAKENFIST_NAMESPACE')
+                    if not key:
+                        key = os.environ.get('SHAKENFIST_KEY')
+
             if not base_url:
                 LOG.debug('Testing for ~/.shakenfist')
                 user_conf = os.path.expanduser('~/.shakenfist')

--- a/shakenfist_client/tests/test_client_apiclient.py
+++ b/shakenfist_client/tests/test_client_apiclient.py
@@ -615,3 +615,49 @@ class ApiClientGetNodesTestCase(testtools.TestCase):
 
         mock_request.assert_called_with(
             'GET', '/nodes')
+
+
+class ApiClientConfigurationLookupTestCase(testtools.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.capabilities = mock.patch(
+            'shakenfist_client.apiclient.Client._collect_capabilities')
+        self.capabilities = self.capabilities.start()
+        self.addCleanup(self.capabilities.stop)
+
+        # Ensure the config files on the test machine are not consulted
+        self.exists = mock.patch(
+            'shakenfist_client.apiclient.os.path.exists', return_value=False)
+        self.mock_exists = self.exists.start()
+        self.addCleanup(self.exists.stop)
+
+    @mock.patch.dict('os.environ', {
+        'SHAKENFIST_API_URL': 'http://sf.example.com/api',
+        'SHAKENFIST_NAMESPACE': 'testspace',
+        'SHAKENFIST_KEY': 'testkey',
+    })
+    def test_environment_variables(self):
+        client = apiclient.Client()
+
+        self.assertEqual('http://sf.example.com/api', client.base_url)
+        self.assertEqual('testspace', client.namespace)
+        self.assertEqual('testkey', client.key)
+
+    @mock.patch.dict('os.environ', {
+        'SHAKENFIST_API_URL': 'http://sf.example.com/api',
+        'SHAKENFIST_NAMESPACE': 'testspace',
+        'SHAKENFIST_KEY': 'testkey',
+    })
+    def test_arguments_beat_environment_variables(self):
+        client = apiclient.Client(
+            base_url='http://elsewhere.example.com/api',
+            namespace='otherspace', key='otherkey')
+
+        self.assertEqual('http://elsewhere.example.com/api', client.base_url)
+        self.assertEqual('otherspace', client.namespace)
+        self.assertEqual('otherkey', client.key)
+
+    @mock.patch.dict('os.environ', {}, clear=True)
+    def test_unconfigured(self):
+        self.assertRaises(apiclient.UnconfiguredException, apiclient.Client)


### PR DESCRIPTION
The apiclient.Client configuration lookup only consulted ~/.shakenfist and /etc/sf/shakenfist.json; the SHAKENFIST_API_URL, SHAKENFIST_NAMESPACE and SHAKENFIST_KEY environment variables were only honoured by the CLI via click. Library callers such as the ansible collection modules therefore ignored the environment, despite their documentation claiming otherwise. This broke conductor's nightly CI image builds on maui (shakenfist/shakenfist issues #3349 through #3359), where credentials are passed in the environment and no config file exists.

The environment is now checked after explicit arguments and before the configuration files, matching the CLI's precedence exactly.

Prompt: The conductor nightly CI image builds all failed with "You have not specified the server to communicate with". Diagnosis showed the collection modules fall back to apiclient.Client(), which never read the SHAKENFIST_* environment variables conductor passes. Mikal asked for the correct fix in client-python: make the client library honour those environment variables like the CLI does.

Assisted-By: Claude Code