### PR TITLE
Add request timeouts to the API client.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -161,6 +161,9 @@ class Client:
             LOG = logger
 
         self.most_recent_request_id = None
+        # Passed as the requests timeout on every HTTP call (connect and
+        # read). Without it a server that accepts the socket but never
+        # responds would block the caller forever.
         self.sync_request_timeout = sync_request_timeout
 
         LOG.debug('Client initially configured with apiurl of %s for namespace %s '
@@ -236,7 +239,8 @@ class Client:
         self._collect_capabilities()
 
     def _collect_capabilities(self):
-        r = self.session.request('GET', self.base_url, allow_redirects=True)
+        r = self.session.request('GET', self.base_url, allow_redirects=True,
+                                 timeout=self.sync_request_timeout)
         self.root_html = r.text
 
     def check_capability(self, capability_string):
@@ -264,14 +268,16 @@ class Client:
         try:
             r = self.session.request(method, url, data=data, headers=h,
                                      allow_redirects=allow_redirects,
-                                     stream=stream)
+                                     stream=stream,
+                                     timeout=self.sync_request_timeout)
 
         except requests.exceptions.ConnectionError:
             # Session was terminated gracelessly, rebuild it
             self.session = requests.Session()
             r = self.session.request(method, url, data=data, headers=h,
                                      allow_redirects=allow_redirects,
-                                     stream=stream)
+                                     stream=stream,
+                                     timeout=self.sync_request_timeout)
 
         end_time = time.time()
 
@@ -332,7 +338,8 @@ class Client:
                                  {'namespace': self.namespace,
                                   'key': self.key}),
                              headers={'Content-Type': 'application/json',
-                                      'User-Agent': get_user_agent()})
+                                      'User-Agent': get_user_agent()},
+                             timeout=self.sync_request_timeout)
         if r.status_code != 200:
             raise UnauthenticatedException('API unauthenticated', 'POST', auth_url,
                                            r.status_code, r.text)


### PR DESCRIPTION
Every HTTP call in apiclient issued its request without a timeout, so requests defaulted to timeout=None and would wait indefinitely. When a cluster accepts the socket but never answers -- an nginx or database outage -- callers block forever instead of failing.

The Client constructor already accepted sync_request_timeout (default 300 seconds), but it was stored and never referenced in the request path, so it had no effect. Wire it up as the requests timeout on the four call sites that lacked one: capability discovery, both requests in _actual_request_url, and _authenticate.

A read timeout surfaces as requests.exceptions.Timeout rather than being caught by the ConnectionError rebuild-and-retry path, so callers see the failure instead of hanging.

This was found while debugging a conductor crash loop: a hung get_instances() call wedged its main loop, its systemd watchdog heartbeat went stale, and the service was SIGABRTed and restarted roughly every seven minutes.

Prompt: While debugging why the private CI conductor reported five of six worker slots, we found it crash-looping on a systemd watchdog timeout and traced the root cause to Shakenfist API calls that could block forever. I asked for two fixes: wire up the unused sync_request_timeout in the client (this change), and a conductor-side timeout wrapper that works regardless of the installed client version.