### PR TITLE
Fix side channel defaulting in instance create.

### DIFF
--- a/shakenfist_client/commandline/instance.py
+++ b/shakenfist_client/commandline/instance.py
@@ -370,13 +370,19 @@ order you specify them being significant.
               help='Add key=value pair to instance metadata eg. affinity=\'{"fastdisk":10}\'')
 @click.option('-s', '--side-channel', type=click.STRING, multiple=True,
               help=('A named side channel which will appear inside the guest as a '
-                    'virtio-serial port.'))
+                    'virtio-serial port or vsock device. If not specified, the '
+                    'server applies its default set (currently sf-agent and '
+                    'sf-agent2, which the in-guest agent requires).'))
+@click.option('--no-side-channels', is_flag=True, default=False,
+              help=('Create the instance with no side channels at all. This '
+                    'disables the in-guest agent.'))
 @click.pass_context
 def instance_create(ctx, name=None, cpus=None, memory=None, network=None, floated=None,
                     networkspec=None, disk=None, diskspec=None, sshkey=None, sshkeydata=None,
                     userdata=None, encodeduserdata=None, placement=None, videospec=None,
                     namespace=None, bios=True, force=False, configdrive=None,
-                    no_secure_boot=True, nvram_template=None, metadata=None, side_channel=None):
+                    no_secure_boot=True, nvram_template=None, metadata=None, side_channel=None,
+                    no_side_channels=False):
     if memory < 128 and not force:
         print('Specified memory size is %dMB. This is very small.' % memory)
         print('Use the --force flag if this is deliberate')
@@ -480,6 +486,23 @@ def instance_create(ctx, name=None, cpus=None, memory=None, network=None, floate
             return
         metadata_def[key] = val
 
+    # click's multiple=True options default to an empty tuple, but the API
+    # distinguishes between None ("apply the server's default side channels,
+    # currently sf-agent and sf-agent2") and an empty list ("no side channels
+    # at all, disabling the in-guest agent"). Sending the empty tuple through
+    # as-is silently disabled the agent on every instance created without an
+    # explicit --side-channel flag, so map "unspecified" to None and require
+    # --no-side-channels for the explicit empty case.
+    if no_side_channels:
+        if side_channel:
+            print('You cannot specify both --side-channel and --no-side-channels')
+            return
+        side_channels = []
+    elif side_channel:
+        side_channels = list(side_channel)
+    else:
+        side_channels = None
+
     kwargs = {
         'force_placement': placement,
         'namespace': namespace,
@@ -489,7 +512,7 @@ def instance_create(ctx, name=None, cpus=None, memory=None, network=None, floate
         'secure_boot': secure_boot,
         'nvram_template': nvram_template,
         'metadata': metadata_def,
-        'side_channels': side_channel
+        'side_channels': side_channels
     }
 
     _show_instance(ctx, ctx.obj['CLIENT'].create_instance(

--- a/shakenfist_client/tests/test_client_commandline_instance.py
+++ b/shakenfist_client/tests/test_client_commandline_instance.py
@@ -68,3 +68,79 @@ class ConsoleDataCommandTestCase(testtools.TestCase):
         self.assertEqual(0, result.exit_code)
         # CSI sequences and NUL stripped; printable text and newline kept.
         self.assertEqual(b'red ok\n', written)
+
+
+def _minimal_instance():
+    """The smallest instance dict _show_instance will print in simple
+    output mode."""
+    return {
+        'uuid': 'fake-uuid',
+        'name': 'testinst',
+        'namespace': 'system',
+        'cpus': 1,
+        'memory': 1024,
+        'disk_spec': [{'type': 'disk', 'bus': None, 'size': 8,
+                       'base': 'debian:13'}],
+        'video': {'model': 'cirrus', 'memory': 16384, 'vdi': 'spice'},
+        'ssh_key': None,
+        'user_data': None,
+        'side_channels': [],
+        'state': 'created',
+    }
+
+
+class CreateSideChannelsTestCase(testtools.TestCase):
+    """Tests for the side channel arguments to ``sf-client instance create``.
+
+    The API treats side_channels=None as "apply the server's default set"
+    and [] as "explicitly no side channels". click's multiple=True options
+    default to an empty tuple, which previously reached the API as [] and
+    silently disabled the in-guest agent for every instance created
+    without an explicit --side-channel flag.
+    """
+
+    def _invoke(self, extra_args):
+        client = mock.Mock()
+        client.create_instance.return_value = _minimal_instance()
+        client.get_instance_metadata.return_value = {}
+        client.get_instance_interfaces.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(
+            instance_cmd.instance,
+            ['create', 'testinst', '1', '1024', '-d', '8@debian:13'] +
+            extra_args,
+            obj={'CLIENT': client, 'OUTPUT': 'simple'},
+            catch_exceptions=False)
+        return result, client
+
+    def test_unspecified_side_channels_sends_none(self):
+        result, client = self._invoke([])
+        self.assertEqual(0, result.exit_code, result.output)
+        kwargs = client.create_instance.call_args.kwargs
+        self.assertIsNone(kwargs['side_channels'])
+
+    def test_explicit_side_channel_is_passed(self):
+        result, client = self._invoke(['-s', 'sf-agent2'])
+        self.assertEqual(0, result.exit_code, result.output)
+        kwargs = client.create_instance.call_args.kwargs
+        self.assertEqual(['sf-agent2'], kwargs['side_channels'])
+
+    def test_multiple_side_channels_are_passed(self):
+        result, client = self._invoke(
+            ['-s', 'sf-agent', '-s', 'sf-agent2'])
+        self.assertEqual(0, result.exit_code, result.output)
+        kwargs = client.create_instance.call_args.kwargs
+        self.assertEqual(
+            ['sf-agent', 'sf-agent2'], kwargs['side_channels'])
+
+    def test_no_side_channels_flag_sends_empty_list(self):
+        result, client = self._invoke(['--no-side-channels'])
+        self.assertEqual(0, result.exit_code, result.output)
+        kwargs = client.create_instance.call_args.kwargs
+        self.assertEqual([], kwargs['side_channels'])
+
+    def test_conflicting_side_channel_flags_refused(self):
+        result, client = self._invoke(
+            ['-s', 'sf-agent2', '--no-side-channels'])
+        client.create_instance.assert_not_called()
+        self.assertIn('cannot specify both', result.output)


### PR DESCRIPTION
The API distinguishes between side_channels=None, which applies the server's default set (currently sf-agent and sf-agent2, required by the in-guest agent), and an explicit empty list, which creates the instance with no side channels at all. The --side-channel click option uses multiple=True, whose default value is an empty tuple, and we passed that straight through to the API as an empty list. Every instance created without an explicit --side-channel flag was therefore silently missing its side channels: no vsock device was attached, the in-guest agent could never connect (binding the loopback CID 1 instead of a real guest CID), and agent state stayed None forever.

Map "unspecified" to None so the server default applies, and add a --no-side-channels flag so the explicit-empty case remains expressible. Passing both --side-channel and --no-side-channels is refused.

Prompt: Debug why the raptor instance on the sfcbr cluster reported "Our v2 vsock CID is 1" for sf-agent. The diagnosis found the CLI sends side_channels=[] when the flag is unset, silently disabling the agent; I was then asked to fix the client.



Claude-Session: https://claude.ai/code/session_01Cjvy8CnKoM8EeABA2Xajuh