### PR TITLE
Add seamless Kerbside VDI console launch (VDI tokens phase 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ cloud platform.
 # Install with test dependencies
 pip install -e ".[test]"
 
+# Install with VDI console support (ryll viewer)
+pip install -e ".[vdi]"
+
 # Run unit tests
 stestr run
 
@@ -33,6 +36,21 @@ tox
 | `shakenfist_client/tests/` | Unit tests |
 | `tools/flake8wrap.sh` | Flake8 wrapper for CI |
 | `pyproject.toml` | Package metadata and dependencies |
+
+## VDI Console Access
+
+`shakenfist_client/commandline/instance.py` hosts the `vdiconsole` and
+`vdiconsolefile` commands, including the proxy-vs-direct launch logic
+and the viewer-selection chain (prefers `ryll` on `PATH`, then falls
+back to `remote-viewer`; proxy connections via `ryll` launch with
+`--url` and never write the token to disk, all other combinations
+write a temporary `.vv` file). `shakenfist_client/apiclient.py` has the
+matching `Client` methods: `get_vdi_console_proxy` (`GET
+/instances/<ref>/vdiconsoleproxy`), `get_vdi_console_proxy_file`
+(fetches the `.vv` body from the URL returned above via a plain
+`requests.get()` -- it must NOT attach an SF bearer token, since the
+capability is already embedded as a JWT in the URL), and
+`get_vdi_token_public_keys` (`GET /admin/vditokenpubkey`).
 
 ## Code Conventions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,6 +54,15 @@ REST API:
   error handling
 - **Async operations**: Supports configurable strategies for
   waiting on asynchronous operations (instance creation, etc.)
+- **VDI console access**: `get_vdi_console_proxy` fetches a
+  Kerbside-proxied console descriptor (`GET
+  /instances/<ref>/vdiconsoleproxy`); `get_vdi_console_proxy_file`
+  fetches the resulting `.vv` file via a plain, unauthenticated
+  `requests.get()` since the capability travels as a JWT embedded in
+  the URL itself; `get_vdi_token_public_keys` fetches the signing
+  public keys (`GET /admin/vditokenpubkey`) used to verify those
+  tokens offline. `get_vdi_console_helper` remains the direct-to-
+  hypervisor fallback.
 
 ### CLI (`main.py`)
 
@@ -87,6 +96,10 @@ with `importlib.metadata`.
 - **Build system**: `setuptools` with `pyproject.toml`
 - **Versioning**: `setuptools_scm` derives version from git tags
 - **Distribution**: Published to PyPI as `shakenfist_client`
+- **Optional extras**: `[vdi]` pulls in
+  [ryll](https://github.com/shakenfist/ryll) on Linux, the preferred
+  VDI viewer for `instance vdiconsole` / `vdiconsolefile`; without it
+  the CLI falls back to `remote-viewer` if present on `PATH`
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,29 @@ or backport packages where necessary.
 
 ## Recent Changes
 
+### Seamless Kerbside VDI Console Launch (2026-07)
+
+Added `instance vdiconsole` / `instance vdiconsolefile` support for
+Kerbside-proxied VDI consoles, alongside the pre-existing
+direct-to-hypervisor path. When the server advertises the
+`vdi-console-proxy` capability, `apiclient.py` exchanges the instance
+reference for a proxy descriptor (`get_vdi_console_proxy`, `GET
+/instances/<ref>/vdiconsoleproxy`) whose URL embeds a short-lived,
+single-use JWT; `get_vdi_console_proxy_file` fetches the resulting
+`.vv` body with a plain, unauthenticated `requests.get()` since the
+token is already in the URL and must not also carry an SF bearer
+token. `get_vdi_token_public_keys` (`GET /admin/vditokenpubkey`)
+exposes the signing keys used to verify those tokens offline.
+
+The CLI's viewer-selection chain in `commandline/instance.py` prefers
+`ryll` (installed via the new `[vdi]` extra, `pip install -e
+".[vdi]"`) on `PATH`, falling back to `remote-viewer`. Proxied
+connections launched through `ryll` use `--url` directly so the token
+is never written to disk; every other combination writes a temporary
+`.vv` file that is deleted after the viewer exits. `--direct` forces
+the pre-existing direct-to-hypervisor path. See the README's "VDI
+console access" section for user-facing details.
+
 ### Plugin Loading Modernization (2026-01)
 
 Replaced deprecated `pkg_resources.iter_entry_points()` with

--- a/README.md
+++ b/README.md
@@ -6,6 +6,44 @@ cloud [Shaken Fist](https://github.com/shakenfist/shakenfist).
 
 The library is a complete interface to the Shaken Fist HTTP API.
 
+## VDI console access
+
+`sf-client instance vdiconsole <ref>` opens a graphical console for an
+instance. When the Shaken Fist server advertises the
+`vdi-console-proxy` capability, the console is opened seamlessly
+through the [Kerbside](https://github.com/shakenfist/kerbside) SPICE
+proxy; otherwise the client falls back to its existing
+direct-to-hypervisor `.vv` path. Either way this "just works" without
+any extra flags.
+
+Install the optional `vdi` extra to get a viewer that supports the
+seamless proxy path out of the box:
+
+```bash
+pip install shakenfist-client[vdi]
+```
+
+This pulls in [`ryll`](https://github.com/shakenfist/ryll) on Linux
+(it is not published for other platforms, so the extra resolves
+cleanly -- but does nothing -- elsewhere). When `ryll` is on `PATH`
+and the proxy is used, the console JWT is never written to disk --
+`ryll` performs the token exchange itself directly from the proxy
+URL.
+
+Two options tune this behaviour:
+
+- `--viewer <ryll|remote-viewer|PATH>` -- override viewer
+  auto-detection, which otherwise prefers `ryll` on `PATH` and falls
+  back to `remote-viewer`.
+- `--direct` -- force the original direct-to-hypervisor `.vv` path,
+  bypassing the Kerbside proxy even when the server advertises it.
+
+`remote-viewer` (from `virt-viewer`) remains fully supported as a
+fallback for either path -- the `.vv` file the client writes is a
+standard virt-viewer file. `sf-client instance vdiconsolefile`
+downloads that same `.vv` file without launching a viewer, and
+accepts `--direct` too.
+
 ## Documentation
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) -- project structure and key components

--- a/docs/plans/PLAN-vdi-console-tokens.md
+++ b/docs/plans/PLAN-vdi-console-tokens.md
@@ -1,0 +1,144 @@
+# Shaken Fist VDI console tokens phase 4: client, CLI, viewer launch
+
+This is the client-python side of a **cross-repository master plan**
+whose plan of record lives in the Shaken Fist repository:
+
+> `shakenfist/docs/plans/PLAN-kerbside-vdi-tokens.md`
+> (branch `vdi-console-tokens` until merged)
+
+Phases 1-2 (Shaken Fist mints signed tokens; `/admin/vditokenpubkey`
+publishes the public keys) and phase 3 (`pip install ryll`) are done.
+This phase makes `sf-client instance vdiconsole` land the user in a
+session over the Kerbside proxy when it is available, and adds the two
+API-client methods Kerbside's source driver (phase 6) will call.
+
+## Decisions
+
+These refine the master plan's open questions 5 and 10 for the client.
+
+1. **Three `apiclient.Client` methods**, thin, matching the existing
+   `get_instance` / `get_vdi_console_helper` style
+   (`apiclient.py:537`, `:1131` — `self._request_url('GET', path)` then
+   `.json()` or `.text`; no internal capability gate — the CLI probes):
+
+   - `get_vdi_console_proxy(instance_ref)` → GET
+     `/instances/<ref>/vdiconsoleproxy`, `return r.json()` (the phase-2
+     `{url, expires_at}` body — a 200 JSON payload, not a redirect, so
+     the default `allow_redirects=True` is harmless).
+   - `get_vdi_console_proxy_file(instance_ref)` → the convenience: call
+     `get_vdi_console_proxy`, then `requests.get(result['url'])` and
+     `return r.text` (the `.vv`). This is a **plain** `requests.get`
+     with a timeout — Kerbside's `/sf-console.vv` endpoint takes no SF
+     auth (the capability is the JWT already embedded in the URL), so
+     it must NOT go through `_request_url` / the SF bearer token.
+     Verifies TLS (requests default).
+   - `get_vdi_token_public_keys()` → GET `/admin/vditokenpubkey`,
+     `return r.json()`. Net-new for Kerbside's phase-6 source driver;
+     unused by the CLI. Its presence in a released client is what
+     phase 6 depends on (see release note below).
+
+2. **`sf-client instance vdiconsole` becomes the seamless path**
+   (`commandline/instance.py:664`). New options:
+   `--viewer <ryll|remote-viewer|PATH>` (override auto-detect) and
+   `--direct` (force the direct-to-hypervisor `.vv`, bypassing the
+   proxy). Path and viewer are chosen as:
+
+   ```
+   direct = --direct or not check_capability('vdi-console-proxy')
+   viewer = --viewer or ('ryll' if shutil.which('ryll') else 'remote-viewer')
+
+   if not direct:                                   # Kerbside proxy path
+       proxy = get_vdi_console_proxy(ref)           # {url, expires_at}
+       if viewer is ryll:
+           run [ryll, '--url', proxy['url']]        # no temp file; JWT never on disk
+       else:
+           vv = get_vdi_console_proxy_file(ref)     # mint + fetch .vv
+           temp = write(vv); run [viewer, temp]; cleanup
+   else:                                            # direct path (unchanged behaviour)
+       vv = get_vdi_console_helper(ref)
+       temp = write(vv)
+       run [ryll, '--file', temp]  (ryll)  |  run [viewer, temp]  (else)
+       cleanup
+   ```
+
+   `ryll --url` (proxy) is the only branch that never writes a file —
+   ryll performs the token exchange itself. Every other branch fetches
+   the `.vv` to a `tempfile.mkstemp()` file and cleans it up in a
+   `finally`, exactly as today. `ryll` accepts `--url <exchange URL>`
+   or `--file <path>` (ryll README); `remote-viewer` only takes a file.
+
+3. **Auto-prefer the proxy when advertised (open question 5, decided).**
+   When the server advertises `vdi-console-proxy` and `--direct` is not
+   given, `vdiconsole` uses the proxy path — that is the seamless
+   mission goal. `--direct` and a proxy-less server both fall back to
+   the existing direct path, which keeps working unconditionally.
+
+4. **List-form `subprocess.run`, never `shell=True`.** The current
+   command uses `subprocess.run(f'remote-viewer {debug} {temp_name}',
+   shell=True)` (`instance.py:685`). Rewrite all launches as arg lists
+   (`subprocess.run([viewer, *args])`). This is a correctness/security
+   fix: we now pass a URL containing a JWT to `ryll --url`, and a
+   shell-interpolated command line is the wrong place for it. `--debug`
+   / verbose still flows through as a list element where applicable.
+
+5. **`vdiconsolefile` works for both paths** (`instance.py:694`). It
+   gains `--direct`; without it, and when the proxy capability is
+   present, it prints the proxy `.vv` (`get_vdi_console_proxy_file`),
+   else the direct `.vv` (`get_vdi_console_helper`). No viewer launch.
+
+6. **Viewer selection collapses to "ryll on PATH" (open question 10,
+   updated for phase 3's embed model).** Phase 3 ships `ryll` as a wheel
+   whose binary lands on `PATH`, so the strawman's "packaged ryll →
+   PATH ryll" distinction is gone: detection is `shutil.which('ryll')`,
+   else `remote-viewer`, with `--viewer` to override. `remote-viewer`
+   must remain a first-class path (the `.vv` we emit is standard
+   virt-viewer format).
+
+7. **`vdi` extra** in `pyproject.toml`
+   (`[project.optional-dependencies]`, currently only `test`): add
+   `vdi = ["ryll ; sys_platform == 'linux'"]` (annotated `# apache2`).
+   The platform marker is deliberate — phase 3 publishes Linux-only
+   `ryll` wheels, so `pip install shakenfist-client[vdi]` must not fail
+   to resolve on macOS/Windows; there, users install a viewer
+   (`remote-viewer` or a ryll release) themselves and the CLI still
+   works.
+
+8. **Release note.** Kerbside phase 6 calls `get_vdi_token_public_keys()`,
+   so a client release (a `v*` tag → the existing Trusted-Publisher /
+   Sigstore `release.yml`) must precede it, and Kerbside then floor-pins
+   `shakenfist-client`. Flagged here; the tag itself is an operator
+   action, not part of this phase.
+
+## Execution
+
+All in the `client-python-wt-vdi-tokens` worktree (branch
+`vdi-console-tokens`), by sub-agents. Review each step's **actual
+files**. 4b depends on 4a; 4c is independent.
+
+| Step | Effort | Model | Brief for sub-agent |
+|------|--------|-------|---------------------|
+| 4a | medium | sonnet | Add the three methods in decision 1 to `shakenfist_client/apiclient.py`, matching `get_instance`/`get_vdi_console_helper`. `get_vdi_console_proxy_file` uses a plain `requests.get(url, timeout=...)` (NOT `_request_url`; no SF auth) and returns `.text`. Add unit tests mirroring the repo's existing apiclient test style (mock `_request_url` to return a fake response with `.json()`/`.text`; mock `requests.get` for the file convenience; assert the proxy-file path does not attach the SF bearer token). |
+| 4b | medium | sonnet | Rework `vdiconsole` and `vdiconsolefile` in `shakenfist_client/commandline/instance.py` per decisions 2-6. Add `--viewer`/`--direct` options; implement the path/viewer matrix; `shutil.which` for detection (add `import shutil`); ALL launches via list-form `subprocess.run([...])` (no `shell=True`); preserve `--debug`/verbose passthrough and the `mkstemp`+`finally` cleanup. Keep the existing `check_capability` incapability messaging style (`sys.stderr.write` + `sys.exit(1)`) for the no-viewer-found and proxy-unavailable-with-`--direct`-absent-but-also-no-direct cases. Add CLI tests mocking `shutil.which`, `subprocess.run`, and the client methods, covering each cell of the matrix (proxy+ryll uses `--url` and writes no temp file; proxy+remote-viewer and both direct branches write+clean a temp file; `--direct` forces direct; `--viewer` overrides). |
+| 4c | low | sonnet | Add the `vdi` extra (decision 7) to `pyproject.toml`. Update `README.md` (and `AGENTS.md`/`ARCHITECTURE.md` if they describe the console commands) for the seamless `vdiconsole`, the `[vdi]` extra, `--viewer`/`--direct`, and the ryll→remote-viewer fallback. Update `sf-client instance vdiconsole --help` text via the click `help=`. |
+
+## Success criteria
+
+* `get_vdi_console_proxy` / `get_vdi_console_proxy_file` /
+  `get_vdi_token_public_keys` exist, are unit-tested, and the
+  proxy-file fetch carries no SF bearer token.
+* Against a proxy-capable server, `sf-client instance vdiconsole` with
+  `ryll` on PATH opens a session via `ryll --url` with the JWT never
+  written to disk; with only `remote-viewer`, it fetches the `.vv` to a
+  temp file and launches it; `--direct` and a proxy-less server use the
+  existing direct path unchanged.
+* No launch uses `shell=True`.
+* `pip install shakenfist-client[vdi]` pulls `ryll` on Linux and
+  resolves cleanly (no `ryll`) elsewhere.
+* `tox` (flake8 + unit tests) passes.
+
+## Out of scope
+
+Kerbside's consumption of `get_vdi_token_public_keys()` and the
+`/sf-console.vv` exchange (phases 5-6); the client `v*` release tag
+(operator action); any change to the direct-to-hypervisor endpoint
+itself (server-side).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,6 @@ test = [
     "tox",                 # mit
     "flake8",              # mit
 ]
+vdi = [
+    "ryll ; sys_platform == 'linux'",   # apache2
+]

--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -1132,6 +1132,24 @@ class Client:
         r = self._request_url('GET', '/instances/' + instance_ref + '/vdiconsolehelper')
         return r.text
 
+    def get_vdi_console_proxy(self, instance_ref):
+        r = self._request_url(
+            'GET', '/instances/' + instance_ref + '/vdiconsoleproxy')
+        return r.json()
+
+    def get_vdi_console_proxy_file(self, instance_ref):
+        # The kerbside URL embeds its own capability (a JWT), so this is a
+        # plain requests.get() and must NOT go through _request_url --
+        # that would incorrectly attach the SF bearer token.
+        result = self.get_vdi_console_proxy(instance_ref)
+        r = requests.get(result['url'], timeout=self.sync_request_timeout)
+        r.raise_for_status()
+        return r.text
+
+    def get_vdi_token_public_keys(self):
+        r = self._request_url('GET', '/admin/vditokenpubkey')
+        return r.json()
+
     def get_screenshot(self, instance_ref):
         if not self.check_capability('instance-screenshot'):
             raise IncapableException(

--- a/shakenfist_client/commandline/instance.py
+++ b/shakenfist_client/commandline/instance.py
@@ -743,7 +743,14 @@ def instance_vdiconsole(ctx, instance_ref=None, viewer=None, direct=False):
             os.unlink(temp_name)
 
 
-@instance.command(name='vdiconsolefile', help='Download a .vv file for the VDI console')
+@instance.command(name='vdiconsolefile',
+                  help='Download a .vv file for the VDI console.\n\n'
+                       'When the server advertises the Kerbside proxy, this '
+                       'downloads a .vv routed through the Kerbside proxy; '
+                       'otherwise it falls back to a direct-to-hypervisor '
+                       '.vv file. Use --direct to force the direct path. '
+                       'Unlike vdiconsole, this prints the file to stdout '
+                       'instead of launching a viewer.')
 @click.argument('instance_ref', type=click.STRING, shell_complete=_get_instances)
 @click.option('--direct', is_flag=True, default=False,
               help='Force the direct-to-hypervisor path, bypassing the '

--- a/shakenfist_client/commandline/instance.py
+++ b/shakenfist_client/commandline/instance.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -661,31 +662,82 @@ def instance_consoledelete(ctx, instance_ref=None):
     ctx.obj['CLIENT'].delete_console_data(instance_ref)
 
 
-@instance.command(name='vdiconsole', help='Launch a VDI console for the instance')
+@instance.command(name='vdiconsole',
+                  help='Launch a VDI console for the instance.\n\n'
+                       'When the server advertises the Kerbside proxy, this '
+                       'seamlessly opens a session through it; otherwise it '
+                       'falls back to a direct-to-hypervisor connection. Use '
+                       '--direct to force the direct path.')
 @click.argument('instance_ref', type=click.STRING, shell_complete=_get_instances)
+@click.option('--viewer', type=click.STRING, default=None,
+              help='Override viewer auto-detection: ryll, remote-viewer, or '
+                   'a path.')
+@click.option('--direct', is_flag=True, default=False,
+              help='Force the direct-to-hypervisor path, bypassing the '
+                   'Kerbside proxy.')
 @click.pass_context
-def instance_vdiconsole(ctx, instance_ref=None):
-    if not ctx.obj['CLIENT'].check_capability('vdi-console-helper'):
+def instance_vdiconsole(ctx, instance_ref=None, viewer=None, direct=False):
+    client = ctx.obj['CLIENT']
+    use_proxy = (not direct) and client.check_capability('vdi-console-proxy')
+
+    # Resolve the viewer executable. Auto-detection prefers ryll (shipped by
+    # the [vdi] extra) and falls back to remote-viewer.
+    if viewer is None:
+        viewer = 'ryll' if shutil.which('ryll') else 'remote-viewer'
+    viewer_exe = shutil.which(viewer) or (
+        viewer if os.path.isabs(viewer) and os.access(viewer, os.X_OK)
+        else None)
+    if viewer_exe is None:
         sys.stderr.write(
-            'Unfortunately this server does not implement VDI console helpers.\n')
+            "Viewer '%s' not found on PATH. Install ryll "
+            '(pip install shakenfist-client[vdi]) or remote-viewer, or pass '
+            '--viewer.\n' % viewer)
         sys.exit(1)
+    is_ryll = os.path.basename(viewer_exe) == 'ryll'
 
-    debug = ''
-    if ctx.obj['VERBOSE']:
-        debug = '--debug'
+    if use_proxy and is_ryll:
+        # ryll performs the token exchange itself; the JWT never touches disk.
+        proxy = client.get_vdi_console_proxy(instance_ref)
+        p = subprocess.run([viewer_exe, '--url', proxy['url']])
+        if ctx.obj['VERBOSE']:
+            print('%s process exited with %d return code'
+                  % (viewer, p.returncode))
+        return
 
-    # We don't use NamedTemporaryFile as a context manager as the .vv file
-    # will also attempt to clean up the file.
+    # Every other path fetches a .vv to a temp file and launches the viewer
+    # against it. We don't use NamedTemporaryFile as a context manager as the
+    # .vv file will also attempt to clean up the file.
+    if use_proxy:
+        vv = client.get_vdi_console_proxy_file(instance_ref)
+    else:
+        # Direct-to-hypervisor path (requires the vdi-console-helper
+        # capability).
+        if not client.check_capability('vdi-console-helper'):
+            sys.stderr.write(
+                'Unfortunately this server does not implement VDI console '
+                'helpers.\n')
+            sys.exit(1)
+        vv = client.get_vdi_console_helper(instance_ref)
+
     (temp_handle, temp_name) = tempfile.mkstemp()
     os.close(temp_handle)
     try:
         with open(temp_name, 'w') as f:
-            f.write(ctx.obj['CLIENT'].get_vdi_console_helper(instance_ref))
+            f.write(vv)
 
-        p = subprocess.run(f'remote-viewer {debug} {temp_name}', shell=True)
+        if is_ryll:
+            args = [viewer_exe, '--file', temp_name]
+        else:
+            args = [viewer_exe]
+            # --debug is remote-viewer's flag; ryll does not accept it.
+            if ctx.obj['VERBOSE']:
+                args.append('--debug')
+            args.append(temp_name)
+
+        p = subprocess.run(args)
         if ctx.obj['VERBOSE']:
-            print('Remote viewer process exited with %d return code'
-                  % p.returncode)
+            print('%s process exited with %d return code'
+                  % (viewer, p.returncode))
     finally:
         if os.path.exists(temp_name):
             os.unlink(temp_name)
@@ -693,14 +745,23 @@ def instance_vdiconsole(ctx, instance_ref=None):
 
 @instance.command(name='vdiconsolefile', help='Download a .vv file for the VDI console')
 @click.argument('instance_ref', type=click.STRING, shell_complete=_get_instances)
+@click.option('--direct', is_flag=True, default=False,
+              help='Force the direct-to-hypervisor path, bypassing the '
+                   'Kerbside proxy.')
 @click.pass_context
-def instance_vdiconsolefile(ctx, instance_ref=None):
-    if not ctx.obj['CLIENT'].check_capability('vdi-console-helper'):
+def instance_vdiconsolefile(ctx, instance_ref=None, direct=False):
+    client = ctx.obj['CLIENT']
+
+    if (not direct) and client.check_capability('vdi-console-proxy'):
+        print(client.get_vdi_console_proxy_file(instance_ref))
+        return
+
+    if not client.check_capability('vdi-console-helper'):
         sys.stderr.write(
             'Unfortunately this server does not implement VDI console helpers.\n')
         sys.exit(1)
 
-    print(ctx.obj['CLIENT'].get_vdi_console_helper(instance_ref))
+    print(client.get_vdi_console_helper(instance_ref))
 
 
 @instance.command(name='snapshot', help='Snapshot instance')

--- a/shakenfist_client/tests/test_client_apiclient.py
+++ b/shakenfist_client/tests/test_client_apiclient.py
@@ -565,6 +565,62 @@ class ApiClientTestCase(testtools.TestCase):
             'GET', '/instances/uuid/consoledata',
             data={'length': 1000}, response_body_is_binary=True)
 
+    def test_get_vdi_console_proxy(self):
+        proxy = {'url': 'https://kerbside.example.com/sf-console.vv?t=xyz',
+                 'expires_at': '2026-07-20T00:00:00Z'}
+        self.mock_request.return_value = mock.Mock(
+            **{'json.return_value': proxy})
+
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        result = client.get_vdi_console_proxy('notreallyauuid')
+
+        self.assertEqual(proxy, result)
+        self.mock_request.assert_called_with(
+            'GET', '/instances/notreallyauuid/vdiconsoleproxy')
+
+    def test_get_vdi_token_public_keys(self):
+        keys = {'keys': [{'kid': 'key-1', 'pem': 'fake-pem'}]}
+        self.mock_request.return_value = mock.Mock(
+            **{'json.return_value': keys})
+
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        result = client.get_vdi_token_public_keys()
+
+        self.assertEqual(keys, result)
+        self.mock_request.assert_called_with(
+            'GET', '/admin/vditokenpubkey')
+
+    @mock.patch('shakenfist_client.apiclient.requests.get')
+    def test_get_vdi_console_proxy_file(self, mock_get):
+        proxy_url = 'https://kerbside.example.com/sf-console.vv?t=xyz'
+        proxy = {'url': proxy_url, 'expires_at': '2026-07-20T00:00:00Z'}
+        self.mock_request.return_value = mock.Mock(
+            **{'json.return_value': proxy})
+        mock_get.return_value = mock.Mock(text='[virt-viewer]\nfake=1\n')
+
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        result = client.get_vdi_console_proxy_file('notreallyauuid')
+
+        self.assertEqual('[virt-viewer]\nfake=1\n', result)
+
+        # The .vv fetch must be a plain requests.get() carrying no SF
+        # bearer token -- not routed through _request_url.
+        mock_get.assert_called_once_with(
+            proxy_url, timeout=client.sync_request_timeout)
+        mock_get.return_value.raise_for_status.assert_called_once_with()
+        self.assertNotIn(
+            mock.call('GET', '/sf-console.vv', data=mock.ANY),
+            self.mock_request.mock_calls)
+        # Only the vdiconsoleproxy round-trip went through _request_url.
+        self.mock_request.assert_called_once_with(
+            'GET', '/instances/notreallyauuid/vdiconsoleproxy')
+        for call_args in mock_get.call_args_list:
+            args, kwargs = call_args
+            self.assertNotIn('headers', kwargs)
+
     def test_get_console_data_decodes_with_replacement(self):
         # Invalid byte 0x80 in the middle should not raise; the decoder is
         # asked to replace it.

--- a/shakenfist_client/tests/test_client_commandline_instance.py
+++ b/shakenfist_client/tests/test_client_commandline_instance.py
@@ -1,4 +1,6 @@
 import io
+import os
+import tempfile
 from unittest import mock
 
 import testtools
@@ -144,3 +146,257 @@ class CreateSideChannelsTestCase(testtools.TestCase):
             ['-s', 'sf-agent2', '--no-side-channels'])
         client.create_instance.assert_not_called()
         self.assertIn('cannot specify both', result.output)
+
+
+class VdiConsoleCommandTestCase(testtools.TestCase):
+    """Tests for ``sf-client instance vdiconsole``.
+
+    The command chooses between the Kerbside proxy path and the direct
+    path (from ``check_capability``/``--direct``) and between the ``ryll``
+    and ``remote-viewer`` executables (from ``shutil.which``/``--viewer``).
+    We mock ``shutil.which``, ``subprocess.run``, ``tempfile.mkstemp`` and
+    the client methods so no real viewer is launched and no real file is
+    needed.
+    """
+
+    def _which(self, present):
+        """Return a fake ``shutil.which`` resolving names in ``present``.
+
+        ``present`` maps a viewer name to its absolute path; anything else
+        resolves to ``None`` (not on PATH).
+        """
+        def which(name):
+            return present.get(name)
+        return which
+
+    def _mkstemp(self):
+        """Return a real ``tempfile.mkstemp`` result so the write/unlink in
+        the temp-file branches operate on an actual (throwaway) file, while
+        recording the name so tests can assert on it."""
+        handle, name = self._real_mkstemp()
+        self._temp_names.append(name)
+        self.addCleanup(
+            lambda: os.path.exists(name) and os.unlink(name))
+        return handle, name
+
+    def _invoke(self, client, args, which_present, verbose=False):
+        self._temp_names = []
+        self._real_mkstemp = tempfile.mkstemp
+        run = mock.Mock(return_value=mock.Mock(returncode=0))
+        mkstemp = mock.Mock(side_effect=self._mkstemp)
+        with mock.patch.object(
+                instance_cmd.shutil, 'which',
+                side_effect=self._which(which_present)) as which, \
+            mock.patch.object(
+                instance_cmd.subprocess, 'run', run), \
+            mock.patch.object(
+                instance_cmd.tempfile, 'mkstemp', mkstemp):
+            runner = CliRunner()
+            result = runner.invoke(
+                instance_cmd.instance,
+                ['vdiconsole'] + args,
+                obj={'CLIENT': client, 'VERBOSE': verbose},
+                catch_exceptions=False)
+        return result, run, mkstemp, which
+
+    def _client(self, proxy_cap=True, helper_cap=True):
+        client = mock.Mock()
+
+        def check_capability(cap):
+            if cap == 'vdi-console-proxy':
+                return proxy_cap
+            if cap == 'vdi-console-helper':
+                return helper_cap
+            return False
+        client.check_capability.side_effect = check_capability
+        client.get_vdi_console_proxy.return_value = {
+            'url': 'https://kerbside.example/sf-console.vv?token=jwt',
+            'expires_at': 1234,
+        }
+        client.get_vdi_console_proxy_file.return_value = '[proxy vv]'
+        client.get_vdi_console_helper.return_value = '[direct vv]'
+        return client
+
+    def test_proxy_ryll_uses_url_and_no_tempfile(self):
+        # Matrix cell: proxy + ryll. ryll does the token exchange itself,
+        # so we pass --url and never mint/fetch or write the .vv.
+        client = self._client(proxy_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['inst-ref'], {'ryll': '/usr/bin/ryll'})
+
+        self.assertEqual(0, result.exit_code, result.output)
+        run.assert_called_once_with(
+            ['/usr/bin/ryll', '--url',
+             'https://kerbside.example/sf-console.vv?token=jwt'])
+        mkstemp.assert_not_called()
+        client.get_vdi_console_proxy.assert_called_once_with('inst-ref')
+        client.get_vdi_console_proxy_file.assert_not_called()
+        client.get_vdi_console_helper.assert_not_called()
+
+    def test_proxy_remote_viewer_writes_tempfile(self):
+        # Matrix cell: proxy + remote-viewer (ryll absent). We fetch the
+        # .vv via the proxy-file convenience, write it to a temp file, and
+        # launch remote-viewer against the file.
+        client = self._client(proxy_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['inst-ref'], {'remote-viewer': '/usr/bin/remote-viewer'})
+
+        self.assertEqual(0, result.exit_code, result.output)
+        mkstemp.assert_called_once()
+        temp_name = self._temp_names[0]
+        run.assert_called_once_with(['/usr/bin/remote-viewer', temp_name])
+        client.get_vdi_console_proxy_file.assert_called_once_with('inst-ref')
+        client.get_vdi_console_proxy.assert_not_called()
+        client.get_vdi_console_helper.assert_not_called()
+        # Temp file cleaned up.
+        self.assertFalse(os.path.exists(temp_name))
+
+    def test_direct_flag_forces_direct_path(self):
+        # Matrix cell: --direct forces the direct-to-hypervisor helper even
+        # though the proxy capability is present.
+        client = self._client(proxy_cap=True, helper_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['--direct', 'inst-ref'], {'ryll': '/usr/bin/ryll'})
+
+        self.assertEqual(0, result.exit_code, result.output)
+        mkstemp.assert_called_once()
+        temp_name = self._temp_names[0]
+        run.assert_called_once_with(['/usr/bin/ryll', '--file', temp_name])
+        client.get_vdi_console_helper.assert_called_once_with('inst-ref')
+        client.get_vdi_console_proxy.assert_not_called()
+        client.get_vdi_console_proxy_file.assert_not_called()
+        self.assertFalse(os.path.exists(temp_name))
+
+    def test_direct_when_server_lacks_proxy_capability(self):
+        # Matrix cell: no --direct, but the server does not advertise the
+        # proxy, so we fall back to the direct helper path.
+        client = self._client(proxy_cap=False, helper_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['inst-ref'], {'ryll': '/usr/bin/ryll'})
+
+        self.assertEqual(0, result.exit_code, result.output)
+        mkstemp.assert_called_once()
+        temp_name = self._temp_names[0]
+        run.assert_called_once_with(['/usr/bin/ryll', '--file', temp_name])
+        client.get_vdi_console_helper.assert_called_once_with('inst-ref')
+        client.get_vdi_console_proxy.assert_not_called()
+        client.get_vdi_console_proxy_file.assert_not_called()
+
+    def test_viewer_override_is_honoured(self):
+        # --viewer forces remote-viewer even when ryll is on PATH.
+        client = self._client(proxy_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['--viewer', 'remote-viewer', 'inst-ref'],
+            {'ryll': '/usr/bin/ryll',
+             'remote-viewer': '/usr/bin/remote-viewer'})
+
+        self.assertEqual(0, result.exit_code, result.output)
+        temp_name = self._temp_names[0]
+        run.assert_called_once_with(['/usr/bin/remote-viewer', temp_name])
+        client.get_vdi_console_proxy_file.assert_called_once_with('inst-ref')
+
+    def test_viewer_not_found_exits_nonzero(self):
+        # Neither ryll nor remote-viewer resolve on PATH.
+        client = self._client(proxy_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['inst-ref'], {})
+
+        self.assertEqual(1, result.exit_code)
+        self.assertIn('not found on PATH', result.output)
+        run.assert_not_called()
+        mkstemp.assert_not_called()
+
+    def test_explicit_viewer_not_found_exits_nonzero(self):
+        # An explicit --viewer that does not resolve also errors out.
+        client = self._client(proxy_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['--viewer', 'nope', 'inst-ref'],
+            {'ryll': '/usr/bin/ryll'})
+
+        self.assertEqual(1, result.exit_code)
+        self.assertIn("Viewer 'nope' not found", result.output)
+        run.assert_not_called()
+
+    def test_ryll_gets_no_debug_when_verbose(self):
+        # Verbose must not add --debug to a ryll launch (not ryll's flag).
+        client = self._client(proxy_cap=False, helper_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['inst-ref'], {'ryll': '/usr/bin/ryll'}, verbose=True)
+
+        self.assertEqual(0, result.exit_code, result.output)
+        temp_name = self._temp_names[0]
+        run.assert_called_once_with(['/usr/bin/ryll', '--file', temp_name])
+        self.assertNotIn('--debug', run.call_args.args[0])
+
+    def test_remote_viewer_gets_debug_when_verbose(self):
+        # Verbose adds --debug for remote-viewer, before the temp file.
+        client = self._client(proxy_cap=False, helper_cap=True)
+        result, run, mkstemp, which = self._invoke(
+            client, ['inst-ref'],
+            {'remote-viewer': '/usr/bin/remote-viewer'}, verbose=True)
+
+        self.assertEqual(0, result.exit_code, result.output)
+        temp_name = self._temp_names[0]
+        run.assert_called_once_with(
+            ['/usr/bin/remote-viewer', '--debug', temp_name])
+
+
+class VdiConsoleFileCommandTestCase(testtools.TestCase):
+    """Tests for ``sf-client instance vdiconsolefile`` (decision 5)."""
+
+    def _invoke(self, client, args):
+        runner = CliRunner()
+        result = runner.invoke(
+            instance_cmd.instance,
+            ['vdiconsolefile'] + args,
+            obj={'CLIENT': client, 'VERBOSE': False},
+            catch_exceptions=False)
+        return result
+
+    def _client(self, proxy_cap=True, helper_cap=True):
+        client = mock.Mock()
+
+        def check_capability(cap):
+            if cap == 'vdi-console-proxy':
+                return proxy_cap
+            if cap == 'vdi-console-helper':
+                return helper_cap
+            return False
+        client.check_capability.side_effect = check_capability
+        client.get_vdi_console_proxy_file.return_value = '[proxy vv]'
+        client.get_vdi_console_helper.return_value = '[direct vv]'
+        return client
+
+    def test_proxy_path_prints_proxy_file(self):
+        client = self._client(proxy_cap=True)
+        result = self._invoke(client, ['inst-ref'])
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertIn('[proxy vv]', result.output)
+        client.get_vdi_console_proxy_file.assert_called_once_with('inst-ref')
+        client.get_vdi_console_helper.assert_not_called()
+
+    def test_direct_flag_prints_helper(self):
+        client = self._client(proxy_cap=True, helper_cap=True)
+        result = self._invoke(client, ['--direct', 'inst-ref'])
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertIn('[direct vv]', result.output)
+        client.get_vdi_console_helper.assert_called_once_with('inst-ref')
+        client.get_vdi_console_proxy_file.assert_not_called()
+
+    def test_no_proxy_capability_prints_helper(self):
+        client = self._client(proxy_cap=False, helper_cap=True)
+        result = self._invoke(client, ['inst-ref'])
+
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertIn('[direct vv]', result.output)
+        client.get_vdi_console_helper.assert_called_once_with('inst-ref')
+        client.get_vdi_console_proxy_file.assert_not_called()
+
+    def test_no_capabilities_exits_nonzero(self):
+        client = self._client(proxy_cap=False, helper_cap=False)
+        result = self._invoke(client, ['inst-ref'])
+
+        self.assertEqual(1, result.exit_code)
+        self.assertIn('does not implement VDI console helpers', result.output)


### PR DESCRIPTION
Phase 4 of the Shaken Fist VDI console tokens integration (master plan:
`docs/plans/PLAN-kerbside-vdi-tokens.md`, tracked in shakenfist).

Wires up the client side of the SF → Kerbside VDI console token flow: SF
mints a short-lived Ed25519 JWT for an instance the caller owns, Kerbside
validates it offline and returns the normal consoletoken + `.vv`, and
`sf-client instance vdiconsole` launches the viewer.

## What this adds

- `get_vdi_console_proxy(instance_ref)` — returns the parsed
  `{url, expires_at}` JSON from SF's `/instances/<ref>/vdiconsoleproxy`.
- `get_vdi_console_proxy_file(instance_ref)` — fetches the Kerbside URL and
  returns the `.vv` text (plain `requests.get`; Kerbside's endpoint takes no
  SF auth).
- `get_vdi_token_public_keys()` — consumed by Kerbside's Shaken Fist source
  driver for offline JWT verification.
- CLI: `sf-client instance vdiconsole` becomes the seamless path — when the
  `vdi-console-proxy` capability is advertised it mints the token and launches
  the viewer (ryll via `--url`, so the token never touches disk;
  `remote-viewer` via a temp `.vv` as before). Viewer selection: packaged ryll
  → PATH ryll → remote-viewer, with `--viewer`/`--direct` overrides.
  `vdiconsolefile` keeps working for both paths.
- Packaging: new `[vdi]` extra depending on `ryll` (the pip-installable viewer
  wheel, released as ryll 0.1.7).

## Release ordering

Kerbside's phase 6 consumes `get_vdi_token_public_keys()`, so this client
release must precede the kerbside pin bump (`shakenfist-client>=`). Effort
merge order: ryll (done) → **client-python** → shakenfist → kerbside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
