### PR TITLE
Treat plain 'error' as terminal in instance awaits.

### DIFF
--- a/shakenfist_client/apiclient.py
+++ b/shakenfist_client/apiclient.py
@@ -138,6 +138,13 @@ def _calculate_async_deadline(strategy):
     raise UnknownAsyncStrategy('Async strategy %s is unknown' % strategy)
 
 
+def _is_error_state(state):
+    # Instances error to transitional states like 'creating-error' before
+    # settling in the terminal 'error' state. Both mean the instance will
+    # never be ready.
+    return state == 'error' or state.endswith('-error')
+
+
 def _correct_blob_indexes(d):
     # JSON requires dictionary keys to be strings. Reverse that for the blobs
     # element here to reduce confusion.
@@ -1350,12 +1357,12 @@ class Client:
         final = False
         while time.time() - start_time < timeout:
             i = self.get_instance(instance_uuid)
-            if i['state'] in ['created', 'error']:
+            if i['state'] == 'created' or _is_error_state(i['state']):
                 final = True
                 break
             time.sleep(5)
 
-        if i['state'].endswith('-error'):
+        if _is_error_state(i['state']):
             raise InstanceWillNeverBeReady(
                 'failed to start (marked as error state, %s)' % i)
 
@@ -1370,7 +1377,7 @@ class Client:
         if inst['state'] == 'deleted':
             raise InstanceWillNeverBeReady('instance deleted')
 
-        if inst['state'].endswith('-error'):
+        if _is_error_state(inst['state']):
             raise InstanceWillNeverBeReady('instance in error state')
 
         if 'sf-agent2' not in inst['side_channels']:

--- a/shakenfist_client/tests/test_client_apiclient.py
+++ b/shakenfist_client/tests/test_client_apiclient.py
@@ -48,6 +48,46 @@ class ApiClientTestCase(testtools.TestCase):
         self.mock_request.assert_called_with(
             'GET', '/instances/notreallyauuid/interfaces')
 
+    def test_await_instance_create_created(self):
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        with mock.patch.object(client, 'get_instance',
+                               return_value={'state': 'created'}):
+            client.await_instance_create('notreallyauuid')
+
+    def test_await_instance_create_error_state(self):
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        with mock.patch.object(client, 'get_instance',
+                               return_value={'state': 'error'}):
+            self.assertRaises(
+                apiclient.InstanceWillNeverBeReady,
+                client.await_instance_create, 'notreallyauuid')
+
+    def test_await_instance_create_transitional_error_state(self):
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        with mock.patch.object(client, 'get_instance',
+                               return_value={'state': 'creating-error'}):
+            self.assertRaises(
+                apiclient.InstanceWillNeverBeReady,
+                client.await_instance_create, 'notreallyauuid')
+
+    def test_instance_await_sanity_check_error_states(self):
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        for state in ['error', 'creating-error']:
+            self.assertRaises(
+                apiclient.InstanceWillNeverBeReady,
+                client._instance_await_sanity_check,
+                {'state': state, 'side_channels': ['sf-agent2']})
+
+    def test_instance_await_sanity_check_healthy(self):
+        client = apiclient.Client(suppress_configuration_lookup=True,
+                                  base_url='http://localhost:13000')
+        client._instance_await_sanity_check(
+            {'state': 'created', 'side_channels': ['sf-agent2']})
+
     def test_create_instance(self):
         client = apiclient.Client(suppress_configuration_lookup=True,
                                   base_url='http://localhost:13000')


### PR DESCRIPTION
`await_instance_create()` broke out of its polling loop on the terminal
`error` state, but only raised `InstanceWillNeverBeReady` for states
matching `endswith('-error')` — which plain `error` does not match. An
instance that landed in `error` was therefore reported as a successful
create. `_instance_await_sanity_check()` had the same gap, so
`await_agent_ready()` and friends would also accept an errored instance.

In shakenfist merge CI this surfaced as the confusing ansible failure
`list object has no element 0` when an under-cloud scheduler 507 errored
an instance and the `sf_instance` module reported it as changed with no
interfaces, instead of a clear "instance in error state" at the create
step (see [shakenfist run 30047290976](https://github.com/shakenfist/shakenfist/actions/runs/30047290976/job/89341364989)).

This change adds an `_is_error_state()` helper covering both the
terminal `error` state and transitional `*-error` states, uses it in
both places (the wait loop now also exits on transitional error states
rather than spinning until they settle), and adds unit coverage for the
error, transitional-error and healthy paths.

Fixes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
